### PR TITLE
mcp: per-tool instrumentation shim (Phase 0, feeds #90/#91)

### DIFF
--- a/mcpsrv/__init__.py
+++ b/mcpsrv/__init__.py
@@ -7,8 +7,8 @@ implementation is split per-concern across submodules:
 * :mod:`mcpsrv.app` — FastMCP instance + index accessor + ``_load_json``
 * :mod:`mcpsrv.indexes` — ``CorpusIndex``, ``TaxonMentionDB``, ``BiblioAuthority``
 * :mod:`mcpsrv.tools.papers` / ``.taxonomy`` / ``.figures`` / ``.chunks``
-  / ``.bibliography`` — the 27 ``@mcp.tool()``-decorated functions, grouped
-  by concern
+  / ``.bibliography`` / ``.lexicon`` — the ``@mcp.tool()``-decorated
+  functions, grouped by concern (see dev_docs/MCP_TOOLS.md for the catalog)
 * :mod:`mcpsrv.transport` — bearer-auth ASGI middleware + SSE runner
 * :mod:`mcpsrv.main` — argparse + index construction + transport dispatch
 """

--- a/mcpsrv/app.py
+++ b/mcpsrv/app.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -74,8 +76,106 @@ def _validated_limit(limit: int, *, max_value: int = MAX_LIMIT) -> int:
     return min(n, max_value)
 
 
+# ---------------------------------------------------------------------------
+# Per-tool instrumentation (Phase 0 — feeds #90 run-log + #91 /healthz)
+# ---------------------------------------------------------------------------
+#
+# A single dispatch-layer interceptor records, per tool, the call count,
+# transport-level error count, and cumulative latency. We hook
+# ``ToolManager.call_tool`` rather than wrapping each ``@mcp.tool()``
+# function: FastMCP builds every tool's JSON-schema from the *function
+# signature* (``Tool.from_function``), so wrapping the functions would
+# risk corrupting that introspection. ``FastMCP.call_tool`` looks up
+# ``self._tool_manager.call_tool`` dynamically on every call
+# (server.py), so replacing that bound method takes effect for both the
+# stdio and SSE transports.
+#
+# "error" here means the dispatch raised (unknown tool, validation
+# failure, or an unhandled exception in the tool body). Tools that
+# *return* an ``{"error": ...}`` row are a normal response at this layer
+# and are not counted — the Phase-3 uniform error-row shape standardizes
+# those payloads separately.
+
+
+class _ToolStats:
+    """Process-wide per-tool counters. Read via :meth:`snapshot`."""
+
+    def __init__(self) -> None:
+        self.calls: dict[str, int] = defaultdict(int)
+        self.errors: dict[str, int] = defaultdict(int)
+        self._latency_ms: dict[str, float] = defaultdict(float)
+
+    def record(self, name: str, latency_ms: float, ok: bool) -> None:
+        self.calls[name] += 1
+        if not ok:
+            self.errors[name] += 1
+        self._latency_ms[name] += latency_ms
+
+    @property
+    def total_calls(self) -> int:
+        return sum(self.calls.values())
+
+    @property
+    def total_errors(self) -> int:
+        return sum(self.errors.values())
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        """Per-tool ``{calls, errors, avg_latency_ms}``, sorted by name."""
+        return {
+            name: {
+                "calls": self.calls[name],
+                "errors": self.errors[name],
+                "avg_latency_ms": (
+                    round(self._latency_ms[name] / self.calls[name], 1)
+                    if self.calls[name]
+                    else 0.0
+                ),
+            }
+            for name in sorted(self.calls)
+        }
+
+
+TOOL_STATS = _ToolStats()
+
+
+def _args_summary(arguments: Any) -> str:
+    """Comma-joined sorted arg names — never values, to keep logs safe."""
+    if isinstance(arguments, dict):
+        return ",".join(sorted(str(k) for k in arguments))
+    return ""
+
+
+def _install_call_instrumentation(mcp_instance: "FastMCP") -> None:
+    """Wrap ``_tool_manager.call_tool`` to feed :data:`TOOL_STATS`."""
+    tm = mcp_instance._tool_manager
+    if getattr(tm, "_corpus_instrumented", False):
+        return  # idempotent — guard against double-import
+    orig_call_tool = tm.call_tool
+
+    async def _instrumented_call_tool(name, arguments=None, *args, **kwargs):
+        start = time.perf_counter()
+        ok = True
+        try:
+            return await orig_call_tool(name, arguments, *args, **kwargs)
+        except Exception:
+            ok = False
+            raise
+        finally:
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            TOOL_STATS.record(name, latency_ms, ok)
+            logger.info(
+                "mcp_tool name=%s args=[%s] latency_ms=%.1f status=%s",
+                name, _args_summary(arguments), latency_ms,
+                "ok" if ok else "error",
+            )
+
+    tm.call_tool = _instrumented_call_tool  # type: ignore[method-assign]
+    tm._corpus_instrumented = True  # type: ignore[attr-defined]
+
+
 # Module-level FastMCP instance — every tools module decorates this one.
 mcp = FastMCP("corpus")
+_install_call_instrumentation(mcp)
 
 # Set by :func:`mcpsrv.main.main` after the corpus index is built.
 # Forward-declared here so tools can reference ``_INDEX`` and

--- a/tests/test_tool_instrumentation.py
+++ b/tests/test_tool_instrumentation.py
@@ -1,0 +1,48 @@
+"""Phase-0 per-tool instrumentation shim (mcpsrv/app.py).
+
+Verifies the dispatch-layer interceptor records call counts, error
+counts, and latency without touching FastMCP's schema generation, and
+that the args summary never leaks argument *values*. Feeds #90 (run
+log) and #91 (/healthz).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcpsrv.app import TOOL_STATS, _args_summary, _ToolStats, mcp
+
+
+def test_tool_stats_math():
+    s = _ToolStats()
+    s.record("t", 10.0, ok=True)
+    s.record("t", 20.0, ok=False)
+    snap = s.snapshot()
+    assert snap["t"] == {"calls": 2, "errors": 1, "avg_latency_ms": 15.0}
+    assert s.total_calls == 2
+    assert s.total_errors == 1
+
+
+def test_args_summary_is_keys_only():
+    # Sorted key names only — never values, so logs can't leak secrets.
+    assert _args_summary({"b": 2, "a": 1}) == "a,b"
+    assert _args_summary(None) == ""
+    assert _args_summary("garbage") == ""
+    assert "hunter2" not in _args_summary({"token": "hunter2"})
+
+
+def test_call_tool_is_instrumented():
+    # The interceptor must be installed on the live FastMCP instance,
+    # and installation must be idempotent under re-import.
+    assert getattr(mcp._tool_manager, "_corpus_instrumented", False) is True
+
+
+def test_dispatch_error_is_recorded_and_reraised():
+    name = "does_not_exist_xyz"
+    before_calls = TOOL_STATS.calls.get(name, 0)
+    before_errors = TOOL_STATS.errors.get(name, 0)
+    with pytest.raises(Exception):
+        asyncio.run(mcp._tool_manager.call_tool(name, {}))
+    assert TOOL_STATS.calls[name] == before_calls + 1
+    assert TOOL_STATS.errors[name] == before_errors + 1


### PR DESCRIPTION
**Phase 0 of the v0.6 API-freeze pass** (PLAN.md Group A). Foundational scaffold consumed by #90 (run log), #91 (/healthz), and the Phase-3 uniform error shape.

## What
- Single dispatch-layer interceptor on `ToolManager.call_tool` records per-tool **call count, transport-level error count, and cumulative latency** into a process-wide `TOOL_STATS`, plus a keys-only `mcp_tool …` log line per call.
- `TOOL_STATS.snapshot()` → `{tool: {calls, errors, avg_latency_ms}}` for downstream consumers.

## Why hook the dispatch path, not each `@mcp.tool()`
FastMCP builds every tool's JSON-schema from the **function signature** (`Tool.from_function`), so wrapping the tool functions risks corrupting introspection. `FastMCP.call_tool` dispatches to `self._tool_manager.call_tool(...)` by dynamic attribute lookup on every call (the low-level handler captures `self.call_tool` at construction, so wrapping that wouldn't take effect) — wrapping `_tool_manager.call_tool` is the one safe, effective interceptor for both stdio and SSE. Installation is idempotent.

## Scope notes
- **Additive** — no tool signature or response-shape change.
- "error" = the dispatch *raised* (unknown tool, validation failure, unhandled exception). Tools that *return* an `{"error": …}` row are a normal response here and aren't counted — Phase 3 standardizes those payloads separately.
- Args summary logs **key names only**, never values (test asserts this).
- Also de-hardcodes the stale "27 tools" docstring in `mcpsrv/__init__.py` (now 39 across 6 files incl. `lexicon`), matching the earlier OVERVIEW/AGENTS/MCP_TOOLS fix.

## Verification
- New `tests/test_tool_instrumentation.py` (4 tests): stats math, keys-only arg summary, interceptor installed, dispatch error recorded + re-raised.
- Full no-corpus unit suite green locally (`corpus` env): **510 passed, 77 skipped** (skips are corpus-dependent). pyflakes clean. Tool registration intact (39 tools).

Refs #90, #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)