### PR TITLE
mcp: lexicon_matrix summary-by-default (#88 Part 1)

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -87,7 +87,7 @@ Category-agnostic — every tool takes `category` as an argument and returns `{"
 
 | Tool | Returns |
 | --- | --- |
-| `lexicon_matrix` | Paper × term mention-count grid for one category. Caller-controlled columns (`terms=`) or top-N by total mention count. Caller-controlled rows (`paper_hashes=`) or all papers, optionally year-filtered. Papers with no `<category>.json` surface as zero-filled rows. Typical ~2 k tokens for 100 × 20. |
+| `lexicon_matrix` | Lexicon-coverage view for one category. **Default `detail=False`** returns compact per-term totals (`term_totals[]` with `total_mentions` + `papers_with_mentions`) over the selected papers. **`detail=True`** returns the full paper × term mention-count grid (`rows[]`), which is O(papers × terms) and was a multi-MB runaway, hence opt-in (#88). Caller-controlled columns (`terms=`) or top-N by total mention count; caller-controlled paper set (`paper_hashes=`) or all papers, optionally year-filtered. |
 | `get_lexicon_term_dossier` | Per-term cross-corpus view: rollup counts, top papers by mention count, chunk examples (IDs only — pair with `get_chunks`), term description. |
 
 ## Prompt-cache integration (Anthropic API clients)

--- a/mcpsrv/tools/lexicon.py
+++ b/mcpsrv/tools/lexicon.py
@@ -93,30 +93,50 @@ def lexicon_matrix(
     paper_hashes: Optional[List[str]] = None,
     year_from: Optional[int] = None,
     year_to: Optional[int] = None,
+    detail: bool = False,
 ) -> Dict[str, Any]:
-    """Paper × term mention-count grid for one lexicon category (#76).
-    Server-side join; ~2 k tokens for 100 × 20.
+    """Lexicon-coverage view for one category (#76, #88).
 
-    Columns: ``terms=[...]`` for a specific set, else top_n by total
-    mention count. Rows: ``paper_hashes=[...]`` else all papers,
-    optionally year-filtered (inclusive), sorted by year desc then
-    hash. Cells: ``terms[].mention_count`` from each paper's
-    ``<category>.json``; papers with no file contribute zero rows.
+    **Default (``detail=False``)** returns compact per-term totals over
+    the selected papers — O(terms), a few hundred bytes for a typical
+    query. **``detail=True``** returns the full paper × term
+    mention-count grid (O(papers × terms)); on a large corpus that grid
+    was a multi-MB runaway, so it is now opt-in (#88).
+
+    Columns/terms: ``terms=[...]`` for a specific set, else top_n by
+    total mention count. Paper set: ``paper_hashes=[...]`` else all
+    papers, optionally year-filtered (inclusive). Counts come from the
+    in-memory mention index; grid cells fall back to each paper's
+    ``<category>.json``.
 
     Category-agnostic. Unknown category returns ``{error:
     "unknown_category", available: [...]}``.
 
-    Returns::
+    Returns (``detail=False``)::
 
         {
           "category": str,
+          "detail": false,
+          "paper_count": int,                 # papers in the selected set
+          "term_totals": [{
+            "term": str,
+            "total_mentions": int,            # summed over the paper set
+            "papers_with_mentions": int,
+          }, ...]                             # column order
+        }
+
+    Returns (``detail=True``)::
+
+        {
+          "category": str,
+          "detail": true,
           "terms": [canonical, ...],          # column order
           "rows": [{
             "paper_hash": str,
             "title": str,
             "year": int | null,
             "counts": [int, ...],             # parallel to terms
-          }, ...]
+          }, ...]                             # one row per paper
         }
     """
     idx = _need_index()
@@ -140,8 +160,38 @@ def lexicon_matrix(
 
     row_hashes = _paper_filter(idx, paper_hashes, year_from, year_to)
 
-    # Per-paper, read the <category>.json once and build a vector
-    # parallel to columns.
+    # Default (detail=False): compact per-term totals over the selected
+    # papers. Summing across the in-memory lexicon_mention_counts (term →
+    # {paper_hash: count}) keeps this O(non-zero cells) and avoids the
+    # per-paper file reads + O(papers × terms) payload that made the full
+    # grid a multi-MB runaway (#88).
+    if not detail:
+        mention_counts = idx.lexicon_mention_counts.get(category, {})
+        row_set = set(row_hashes)
+        term_totals: List[Dict[str, Any]] = []
+        for t in columns:
+            per_paper = mention_counts.get(t, {})
+            total = 0
+            papers_with = 0
+            for h, c in per_paper.items():
+                c = c or 0
+                if h in row_set and c:
+                    total += c
+                    papers_with += 1
+            term_totals.append({
+                "term": t,
+                "total_mentions": total,
+                "papers_with_mentions": papers_with,
+            })
+        return {
+            "category": category,
+            "detail": False,
+            "paper_count": len(row_hashes),
+            "term_totals": term_totals,
+        }
+
+    # detail=True: the full paper × term grid. Read each paper's
+    # <category>.json once and build a vector parallel to columns.
     rows: List[Dict[str, Any]] = []
     column_index = {t: i for i, t in enumerate(columns)}
     for h in row_hashes:
@@ -166,6 +216,7 @@ def lexicon_matrix(
 
     return {
         "category": category,
+        "detail": True,
         "terms": columns,
         "rows": rows,
     }

--- a/tests/test_lexicon_tools.py
+++ b/tests/test_lexicon_tools.py
@@ -147,47 +147,73 @@ def test_matrix_default_columns_are_top_n_by_mention_count(corpus):
     out = lexicon_matrix("anatomy", top_n=2)
     # pneumatophore: 5+1=6, tentacle: 3, nectophore: 2 → top-2 is
     # pneumatophore, tentacle.
-    assert out["terms"] == ["pneumatophore", "tentacle"]
+    assert [t["term"] for t in out["term_totals"]] == ["pneumatophore", "tentacle"]
 
 
 def test_matrix_caller_columns_preserve_order_and_drop_unknown(corpus):
     out = lexicon_matrix("anatomy", terms=["tentacle", "no_such_term", "nectophore"])
-    assert out["terms"] == ["tentacle", "nectophore"]
+    assert [t["term"] for t in out["term_totals"]] == ["tentacle", "nectophore"]
 
 
-def test_matrix_rows_sorted_by_year_desc_then_hash(corpus):
+# --- #88: summary is the default; the full grid is opt-in (detail=True) ---
+
+
+def test_matrix_default_is_summary_not_grid(corpus):
     out = lexicon_matrix("anatomy", terms=["pneumatophore"])
+    assert out["detail"] is False
+    assert "rows" not in out          # the O(papers×terms) runaway is gone
+    assert out["paper_count"] == 3
+    assert out["term_totals"][0] == {
+        "term": "pneumatophore",
+        "total_mentions": 6,          # a:5 + b:1
+        "papers_with_mentions": 2,    # c has no anatomy.json
+    }
+
+
+def test_matrix_summary_totals_respect_year_filter(corpus):
+    out = lexicon_matrix("anatomy", terms=["pneumatophore"],
+                         year_from=2010, year_to=2010)
+    # 2010 papers are b (pneumatophore=1) and c (no file).
+    assert out["paper_count"] == 2
+    assert out["term_totals"][0]["total_mentions"] == 1
+    assert out["term_totals"][0]["papers_with_mentions"] == 1
+
+
+def test_matrix_detail_rows_sorted_by_year_desc_then_hash(corpus):
+    out = lexicon_matrix("anatomy", terms=["pneumatophore"], detail=True)
+    assert out["detail"] is True
     row_hashes = [r["paper_hash"] for r in out["rows"]]
     # 2010 papers first (b, c by hash), then 2005 (a).
     assert row_hashes == ["bbbbbbbbbbbb", "cccccccccccc", "aaaaaaaaaaaa"]
 
 
-def test_matrix_paper_with_no_category_file_is_zero_row(corpus):
+def test_matrix_detail_paper_with_no_category_file_is_zero_row(corpus):
     """Paper cccc has no anatomy.json. The contract is that it still
-    appears in the matrix as a zero-filled row — papers shouldn't
+    appears in the grid as a zero-filled row — papers shouldn't
     silently disappear from coverage tables just because they have
     no hits in the chosen category."""
-    out = lexicon_matrix("anatomy", terms=["pneumatophore", "tentacle"])
+    out = lexicon_matrix("anatomy", terms=["pneumatophore", "tentacle"], detail=True)
     row_c = next(r for r in out["rows"] if r["paper_hash"] == "cccccccccccc")
     assert row_c["counts"] == [0, 0]
 
 
-def test_matrix_counts_match_per_paper_mention_counts(corpus):
-    out = lexicon_matrix("anatomy", terms=["pneumatophore", "nectophore"])
+def test_matrix_detail_counts_match_per_paper_mention_counts(corpus):
+    out = lexicon_matrix("anatomy", terms=["pneumatophore", "nectophore"],
+                         detail=True)
     row_a = next(r for r in out["rows"] if r["paper_hash"] == "aaaaaaaaaaaa")
     assert row_a["counts"] == [5, 2]
 
 
-def test_matrix_year_filter_restricts_rows(corpus):
+def test_matrix_detail_year_filter_restricts_rows(corpus):
     out = lexicon_matrix("anatomy", terms=["pneumatophore"],
-                         year_from=2010, year_to=2010)
+                         year_from=2010, year_to=2010, detail=True)
     hashes = {r["paper_hash"] for r in out["rows"]}
     assert hashes == {"bbbbbbbbbbbb", "cccccccccccc"}
 
 
-def test_matrix_paper_hashes_filter_restricts_rows(corpus):
+def test_matrix_detail_paper_hashes_filter_restricts_rows(corpus):
     out = lexicon_matrix("anatomy", terms=["pneumatophore"],
-                         paper_hashes=["aaaaaaaaaaaa", "bogus"])
+                         paper_hashes=["aaaaaaaaaaaa", "bogus"], detail=True)
     hashes = {r["paper_hash"] for r in out["rows"]}
     assert hashes == {"aaaaaaaaaaaa"}
 


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** (PLAN.md Group A; [#88](https://github.com/caseywdunn/corpus/issues/88) Part 1).

## What
`lexicon_matrix` gains `detail: bool = False`.
- **Default (`detail=False`)** → compact `term_totals[]` (`{term, total_mentions, papers_with_mentions}`) over the selected papers, plus `paper_count`. Computed from the in-memory `lexicon_mention_counts` index — no per-paper file reads, O(non-zero cells).
- **`detail=True`** → the existing full paper × term grid (`rows[]`), unchanged.

## Why
The full grid is O(papers × terms) and was the 71 MB → 684 KB token runaway. Making the compact totals the default fixes that while keeping the grid available on request.

## Breaking
Clients that read `rows[]` must pass `detail=True`. The response now carries a `detail` flag so a client can tell which shape it got. CHANGELOG migration note deferred to the consolidated Phase-3 entry.

## Verification
- `tests/test_lexicon_tools.py` updated: column tests read `term_totals`; new summary-default tests (totals, `papers_with_mentions`, year-filtered totals, no `rows` key); grid tests now pass `detail=True`. **17 passed** locally (`corpus` env). pyflakes clean.
- `dev_docs/MCP_TOOLS.md` catalog row updated for the new default.

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)