### PR TITLE
mcp: batched format_citations (#88 Part 1)

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # MCP tool surface
 
-The MCP server exposes 39 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
+The MCP server exposes 40 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
 
 This table is generated from the docstrings in the source; when the server definition changes, regenerate with:
 
@@ -54,6 +54,7 @@ for f in sorted(pathlib.Path('mcpsrv/tools').glob('*.py')):
 | `get_citation_graph` | Citation graph around a work or paper (in / out / both). |
 | `resolve_reference` | Resolve a free-text bibliographic reference to a work in the authority database. |
 | `format_citation` | Fully-assembled citation string for a work in the authority DB, plus provenance tier (`bib` / `grobid_reconciled` / `unresolved`) and verbatim warning footnote. The route for every citation an LLM client emits — never recombine fields client-side. |
+| `format_citations` | Batched `format_citation` (#88): pass one of `queries` / `work_ids` / `paper_hashes` (a list); returns `citations[]` in input order, each the `format_citation` payload or a per-item error. Prefer this over N single calls when emitting a reference list. |
 | `get_missing_references` | Works cited by corpus papers that are NOT in the corpus. |
 | `get_works_by_author` | All works by an author across the full bibliographic authority database (corpus papers + cited references + taxonomic-authority stubs). |
 | `get_original_description` | Find the original-description paper for a taxon. |
@@ -113,7 +114,7 @@ client.messages.create(
 Two breakpoints land below the ~5 k-token cache-eligibility floor on typical bundles:
 
 - **System prompt** (`mcpsrv/default_instructions.md` concatenated with any corpuscle-specific `instructions.md`): ~500–1500 tokens.
-- **Tool catalog** (39 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
+- **Tool catalog** (40 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
 
 Together ~5 k tokens get cached across all turns of a session — a non-trivial saving on conversations that fan out into many tool-use rounds. Cache lives ~5 minutes by default; subsequent sessions against the same build hit the same cache lines.
 

--- a/mcpsrv/tools/bibliography.py
+++ b/mcpsrv/tools/bibliography.py
@@ -348,6 +348,109 @@ _PROVENANCE_WARNING = {
 }
 
 
+def _resolve_work_for_citation(
+    idx, *, query=None, work_id=None, paper_hash=None,
+) -> Dict[str, Any]:
+    """Resolve exactly one selector to a single ``works`` row.
+
+    Returns ``{"work": <row>}`` on success, or an error dict
+    (``not_found`` / ``ambiguous`` / parse failure) otherwise. The
+    caller validates that exactly one of ``query`` / ``work_id`` /
+    ``paper_hash`` is non-None. Shared by ``format_citation`` (single)
+    and ``format_citations`` (batched).
+    """
+    if work_id is not None:
+        work = idx.biblio_db.get_work(work_id)
+        if work is None:
+            return {"error": "not_found", "work_id": work_id}
+        return {"work": work}
+    if paper_hash is not None:
+        work = idx.biblio_db.get_work_by_corpus_hash(paper_hash)
+        if work is None:
+            return {"error": "not_found", "paper_hash": paper_hash}
+        return {"work": work}
+
+    # query: parse "Author Year [Title]".
+    import re
+    m = re.match(r"^([A-Za-zÀ-ÿ\-\s]+?)[\s,]+(\d{4})\b", (query or "").strip())
+    if not m:
+        return {
+            "error": "could not parse author/year from query — "
+                     "pass work_id explicitly or refine query",
+            "queried": query,
+        }
+    author = m.group(1).strip()
+    year = int(m.group(2))
+    title_frag = query.replace(author, "", 1).strip()
+    title_frag = title_frag.replace(str(year), "", 1).strip(" ,;:")
+    results = idx.biblio_db.search_works(
+        author, year, title_frag if title_frag else None,
+    )
+    if not results:
+        # Broaden: drop the title constraint and retry.
+        results = idx.biblio_db.search_works(author, year)
+    if not results:
+        return {
+            "error": "not_found",
+            "queried": query,
+            "parsed_author": author,
+            "parsed_year": year,
+        }
+    if len(results) > 1:
+        return {
+            "error": "ambiguous",
+            "queried": query,
+            "matches": [
+                {"work_id": r["work_id"], "title": r.get("title"),
+                 "year": r.get("year"), "journal": r.get("journal")}
+                for r in results
+            ],
+        }
+    work = idx.biblio_db.get_work(results[0]["work_id"])
+    if work is None:  # search_works returned a row, get_work lost it
+        return {"error": "not_found", "queried": query}
+    return {"work": work}
+
+
+def _format_resolved_work(idx, work, style) -> Dict[str, Any]:
+    """Render a resolved ``works`` row to the citation payload."""
+    from bib.format import format_citation as _format_str
+
+    # Assemble fields. volume + pages aren't on works.* — TODO when
+    # the bibliography subsystem persists per-citation locator info.
+    fields: Dict[str, Any] = {
+        "authors": idx.biblio_db.get_authors(work["work_id"]),
+        "year": work.get("year"),
+        "title": work.get("title"),
+        "journal": work.get("journal"),
+        "volume": None,
+        "pages": None,
+        "doi": work.get("doi"),
+    }
+    rendered = _format_str(fields, style=style)
+    provenance = idx.biblio_db.provenance(work["work_id"])
+    return {
+        "work_id": work["work_id"],
+        "formatted": rendered["formatted"],
+        "inline": rendered["inline"],
+        "provenance": provenance,
+        "warning": _PROVENANCE_WARNING[provenance],
+        "fields": fields,
+    }
+
+
+def _format_one(
+    idx, *, query=None, work_id=None, paper_hash=None, style="author-year",
+) -> Dict[str, Any]:
+    """Resolve one selector and render it, else return the resolve error."""
+    resolved = _resolve_work_for_citation(
+        idx, query=query, work_id=work_id, paper_hash=paper_hash,
+    )
+    if "work" not in resolved:
+        return resolved
+    return _format_resolved_work(idx, resolved["work"], style)
+
+
 @mcp.tool()
 def format_citation(
     query: Optional[str] = None,
@@ -377,7 +480,7 @@ def format_citation(
     on no match returns ``{error: "not_found", ...}`` — say "not in
     the corpus" rather than fabricating one.
     """
-    from bib.format import SUPPORTED_STYLES, format_citation as _format_str
+    from bib.format import SUPPORTED_STYLES
 
     idx = _need_index()
     if idx.biblio_db is None:
@@ -391,78 +494,78 @@ def format_citation(
         return {
             "error": "provide exactly one of: query, work_id, paper_hash",
         }
+    return _format_one(
+        idx, query=query, work_id=work_id, paper_hash=paper_hash, style=style,
+    )
 
-    # Resolve to a single works row.
-    work: Optional[Dict] = None
-    if work_id is not None:
-        work = idx.biblio_db.get_work(work_id)
-        if work is None:
-            return {"error": "not_found", "work_id": work_id}
-    elif paper_hash is not None:
-        work = idx.biblio_db.get_work_by_corpus_hash(paper_hash)
-        if work is None:
-            return {"error": "not_found", "paper_hash": paper_hash}
-    else:  # query is not None
-        import re
-        m = re.match(r"^([A-Za-zÀ-ÿ\-\s]+?)[\s,]+(\d{4})\b", query.strip())
-        if not m:
-            return {
-                "error": "could not parse author/year from query — "
-                         "pass work_id explicitly or refine query",
-                "queried": query,
-            }
-        author = m.group(1).strip()
-        year = int(m.group(2))
-        title_frag = query.replace(author, "", 1).strip()
-        title_frag = title_frag.replace(str(year), "", 1).strip(" ,;:")
-        results = idx.biblio_db.search_works(
-            author, year, title_frag if title_frag else None,
-        )
-        if not results:
-            # Broaden: drop the title constraint and retry.
-            results = idx.biblio_db.search_works(author, year)
-        if not results:
-            return {
-                "error": "not_found",
-                "queried": query,
-                "parsed_author": author,
-                "parsed_year": year,
-            }
-        if len(results) > 1:
-            return {
-                "error": "ambiguous",
-                "queried": query,
-                "matches": [
-                    {"work_id": r["work_id"], "title": r.get("title"),
-                     "year": r.get("year"), "journal": r.get("journal")}
-                    for r in results
-                ],
-            }
-        work = idx.biblio_db.get_work(results[0]["work_id"])
-        if work is None:  # search_works returned a row, get_work lost it
-            return {"error": "not_found", "queried": query}
 
-    # Assemble fields. volume + pages aren't on works.* — TODO when
-    # the bibliography subsystem persists per-citation locator info.
-    fields: Dict[str, Any] = {
-        "authors": idx.biblio_db.get_authors(work["work_id"]),
-        "year": work.get("year"),
-        "title": work.get("title"),
-        "journal": work.get("journal"),
-        "volume": None,
-        "pages": None,
-        "doi": work.get("doi"),
-    }
-    rendered = _format_str(fields, style=style)
-    provenance = idx.biblio_db.provenance(work["work_id"])
-    return {
-        "work_id": work["work_id"],
-        "formatted": rendered["formatted"],
-        "inline": rendered["inline"],
-        "provenance": provenance,
-        "warning": _PROVENANCE_WARNING[provenance],
-        "fields": fields,
-    }
+@mcp.tool()
+def format_citations(
+    queries: Optional[List[str]] = None,
+    work_ids: Optional[List[str]] = None,
+    paper_hashes: Optional[List[str]] = None,
+    style: str = "author-year",
+) -> Dict[str, Any]:
+    """Batched :func:`format_citation` — format many citations in one
+    call (#88). Prefer this over N single calls when emitting a
+    reference list.
+
+    Pass exactly one of ``queries`` / ``work_ids`` / ``paper_hashes``
+    (a non-empty list); each element resolves and renders exactly as
+    the single tool, in input order. **Use this for every citation you
+    emit** — never recombine author / year / journal / title in your
+    own context. Paste each ``formatted`` + ``inline`` verbatim and
+    append any non-empty ``warning`` verbatim.
+
+    Returns::
+
+        {
+          "style": str,
+          "count": int,
+          "citations": [ <per-item>, ... ]   # input order
+        }
+
+    where each ``<per-item>`` is the :func:`format_citation` payload
+    (``{work_id, formatted, inline, provenance, warning, fields}``) or
+    a per-item error dict (``not_found`` / ``ambiguous`` / parse
+    failure / ``empty_item``). The batch as a whole succeeds even if
+    individual items fail. Top-level errors (bad ``style``, no/many
+    selectors) return ``{error: ...}`` without a ``citations`` list.
+    """
+    from bib.format import SUPPORTED_STYLES
+
+    idx = _need_index()
+    if idx.biblio_db is None:
+        return {"error": "bibliographic authority database not configured"}
+    if style not in SUPPORTED_STYLES:
+        return {
+            "error": f"unknown style {style!r}",
+            "supported_styles": sorted(SUPPORTED_STYLES),
+        }
+    provided = [
+        (name, lst) for name, lst in (
+            ("queries", queries),
+            ("work_ids", work_ids),
+            ("paper_hashes", paper_hashes),
+        ) if lst is not None
+    ]
+    if len(provided) != 1:
+        return {
+            "error": "provide exactly one of: queries, work_ids, paper_hashes",
+        }
+    kind, items = provided[0]
+    if not isinstance(items, list) or not items:
+        return {"error": f"{kind} must be a non-empty list"}
+
+    selector = {"queries": "query", "work_ids": "work_id",
+                "paper_hashes": "paper_hash"}[kind]
+    citations: List[Dict[str, Any]] = []
+    for item in items:
+        if item is None or (isinstance(item, str) and not item.strip()):
+            citations.append({"error": "empty_item", "kind": kind})
+            continue
+        citations.append(_format_one(idx, style=style, **{selector: item}))
+    return {"style": style, "count": len(citations), "citations": citations}
 
 
 @mcp.tool()

--- a/tests/test_format_citation_tool.py
+++ b/tests/test_format_citation_tool.py
@@ -19,7 +19,11 @@ import pytest
 from bib.authority import create_schema
 from mcpsrv import app as mcp_app
 from mcpsrv.indexes import BiblioAuthority
-from mcpsrv.tools.bibliography import _PROVENANCE_WARNING, format_citation
+from mcpsrv.tools.bibliography import (
+    _PROVENANCE_WARNING,
+    format_citation,
+    format_citations,
+)
 
 
 def _make_authority_db(path: Path) -> sqlite3.Connection:
@@ -239,3 +243,64 @@ def test_warning_table_is_complete():
     tool — this test forces them to evolve together."""
     expected_tiers = {"bib", "grobid_reconciled", "unresolved"}
     assert set(_PROVENANCE_WARNING.keys()) == expected_tiers
+
+
+# ---------------------------------------------------------------------------
+# format_citations — batched (#88)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_work_ids_preserve_input_order_and_tiers(index):
+    out = format_citations(work_ids=[
+        "corpus:lensia|1965|unknown",      # unresolved
+        "corpus:dunn|2005|marrus",         # bib
+        "corpus:siebert|2011|hapless",     # grobid_reconciled
+    ])
+    assert out["style"] == "author-year"
+    assert out["count"] == 3
+    provs = [c["provenance"] for c in out["citations"]]
+    assert provs == ["unresolved", "bib", "grobid_reconciled"]
+    # warnings track provenance and match the single-tool table
+    assert out["citations"][1]["warning"] == ""  # bib tier, no warning
+    assert out["citations"][0]["warning"] == _PROVENANCE_WARNING["unresolved"]
+
+
+def test_batch_matches_single_tool_per_item(index):
+    one = format_citation(work_id="corpus:dunn|2005|marrus")
+    batch = format_citations(work_ids=["corpus:dunn|2005|marrus"])
+    assert batch["citations"][0] == one
+
+
+def test_batch_queries_and_paper_hashes(index):
+    by_query = format_citations(queries=["Dunn 2005"])
+    assert by_query["citations"][0]["work_id"] == "corpus:dunn|2005|marrus"
+    by_hash = format_citations(paper_hashes=["dunnhash000"])
+    assert by_hash["citations"][0]["work_id"] == "corpus:dunn|2005|marrus"
+
+
+def test_batch_per_item_errors_do_not_fail_the_batch(index):
+    out = format_citations(work_ids=[
+        "corpus:dunn|2005|marrus",   # ok
+        "corpus:nope|9999|ghost",    # not_found
+        "",                          # empty_item
+    ])
+    assert out["count"] == 3
+    assert out["citations"][0]["work_id"] == "corpus:dunn|2005|marrus"
+    assert out["citations"][1]["error"] == "not_found"
+    assert out["citations"][2]["error"] == "empty_item"
+
+
+def test_batch_requires_exactly_one_selector(index):
+    none = format_citations()
+    assert "exactly one of" in none["error"]
+    both = format_citations(queries=["Dunn 2005"], work_ids=["corpus:dunn|2005|marrus"])
+    assert "exactly one of" in both["error"]
+    assert "citations" not in both
+
+
+def test_batch_rejects_empty_list_and_bad_style(index):
+    empty = format_citations(work_ids=[])
+    assert "non-empty list" in empty["error"]
+    bad = format_citations(work_ids=["corpus:dunn|2005|marrus"], style="vancouver")
+    assert "unknown style" in bad["error"]
+    assert "citations" not in bad


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** ([#88](https://github.com/caseywdunn/corpus/issues/88) Part 1). Net-new tool (Part 1 is unmerged — see PLAN.md planning note).

## What
- Extract the single-resolve body of `format_citation` into shared helpers: `_resolve_work_for_citation`, `_format_resolved_work`, `_format_one`.
- New `format_citations(queries | work_ids | paper_hashes, style)` → `{style, count, citations[]}` in input order. Each element is the `format_citation` payload or a per-item error; **per-item failures don't fail the batch**. Top-level errors (bad `style`, zero/multiple selectors, empty list) return `{error}` with no `citations`.
- `format_citation` is behaviorally unchanged (now delegates to `_format_one`).

## Why
The reference-list use case made N single calls. The batched tool collapses that to one. It must exist **before** Phase 2 removes the singular `format_citation` (§2.3) — guarded by the PLAN landmine.

## Verification
- `tests/test_format_citation_tool.py`: all 12 existing singular tests still pass (behavior unchanged); +6 batched tests (input-order across tiers, parity with single tool, queries/paper_hashes paths, mixed per-item errors, selector validation, empty-list/bad-style). **18 passed** locally (`corpus` env). pyflakes clean.
- `dev_docs/MCP_TOOLS.md`: new catalog row + count 39 → 40.

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)