### PR TITLE
mcp: with_cites= on get_chunks_for_topic (#88 Part 1)

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -78,7 +78,7 @@ Requires `embed_chunks.py` to have been run (for `get_chunks_for_topic`) and `AN
 
 | Tool | Returns |
 | --- | --- |
-| `get_chunks_for_topic` | Semantic search over chunks via the LanceDB vector index. Pass `with_text=False` for a metadata-only scan (#82): ~80 chars/row vs ~600 with full text, then drill down with `get_chunks(paper_hash, chunk_ids=[...])`. |
+| `get_chunks_for_topic` | Semantic search over chunks via the LanceDB vector index. Pass `with_text=False` for a metadata-only scan (#82): ~80 chars/row vs ~600 with full text, then drill down with `get_chunks(paper_hash, chunk_ids=[...])`. Pass `with_cites=True` (#88) to attach `cited_work_ids` (the chunk's parent paper's in-text citation targets) — feed to `format_citations`. |
 | `translate_chunk` | Translate one chunk to the target language (default English), via the Anthropic Claude API. |
 
 ## Lexicon

--- a/mcpsrv/tools/chunks.py
+++ b/mcpsrv/tools/chunks.py
@@ -245,6 +245,7 @@ def get_chunks_for_topic(
     k: int = 20,
     paper_hash: Optional[str] = None,
     with_text: bool = True,
+    with_cites: bool = False,
 ) -> List[Dict]:
     """Semantic top-``k`` chunks via LanceDB cosine similarity. Use
     for "how is X discussed in the corpus" — for literal taxa /
@@ -257,6 +258,14 @@ def get_chunks_for_topic(
     relevant chunk_ids, fetch full text via
     ``get_chunks(paper_hash, chunk_ids=[...])``. Cuts a typical
     k=10 search's body-text cost by ~45%.
+
+    ``with_cites=True`` (#88) attaches ``cited_work_ids`` to each
+    row — the distinct works the chunk's *parent paper* cites in-text,
+    resolved via the bibliographic authority (deduplicated per paper).
+    Feed them straight to ``format_citations`` to build a reference
+    list. Empty list when the authority DB isn't loaded. Citation spans
+    are tracked per paper, not per chunk, so every chunk from the same
+    paper carries the same list.
 
     Pass ``paper_hash`` to constrain to one paper. Returns
     ``[{error: ...}]`` if no LanceDB index exists yet — build with
@@ -277,6 +286,25 @@ def get_chunks_for_topic(
     if paper_hash:
         search = search.where(f"metadata.pdf_hash = '{paper_hash}'")
     results = search.to_list()
+
+    # #88 — per-paper in-text citation targets, loaded once per paper.
+    _cites_cache: Dict[str, List[str]] = {}
+    biblio = getattr(idx, "biblio_db", None)
+
+    def _cited_work_ids(h: str) -> List[str]:
+        if h not in _cites_cache:
+            if biblio is None:
+                _cites_cache[h] = []
+            else:
+                rows = biblio.conn.execute(
+                    "SELECT DISTINCT cited_work_id FROM citations "
+                    "WHERE citing_corpus_hash = ? AND cited_work_id IS NOT NULL "
+                    "ORDER BY cited_work_id",
+                    (h,),
+                ).fetchall()
+                _cites_cache[h] = [row[0] for row in rows]
+        return _cites_cache[h]
+
     out: List[Dict] = []
     for r in results:
         m = r.get("metadata") or {}
@@ -301,6 +329,8 @@ def get_chunks_for_topic(
             row["text"] = text
         else:
             row["len_chars"] = len(text)
+        if with_cites:
+            row["cited_work_ids"] = _cited_work_ids(h) if h else []
         out.append(row)
     return out
 

--- a/tests/test_chunks_for_topic_with_text.py
+++ b/tests/test_chunks_for_topic_with_text.py
@@ -43,7 +43,28 @@ class _FakeEmbedder:
         return [[0.0] * 3 for _ in queries]
 
 
-def _make_index(results: List[Dict]):
+class _FakeBiblioDB:
+    """Minimal biblio_db stub exposing ``.conn.execute(...).fetchall()``
+    for the cited_work_ids query in get_chunks_for_topic(with_cites=True)."""
+
+    def __init__(self, cites_by_paper: Dict[str, List[str]]):
+        self._cites = cites_by_paper
+
+    class _Conn:
+        def __init__(self, outer):
+            self._outer = outer
+
+        def execute(self, _sql: str, params: Tuple):
+            paper_hash = params[0]
+            rows = [(wid,) for wid in self._outer._cites.get(paper_hash, [])]
+            return types.SimpleNamespace(fetchall=lambda: rows)
+
+    @property
+    def conn(self):
+        return self._Conn(self)
+
+
+def _make_index(results: List[Dict], biblio_db=None):
     """Build a CorpusIndex-shaped stub with a synthetic topic-searcher
     that returns the given LanceDB row records."""
     embedder = _FakeEmbedder()
@@ -52,6 +73,7 @@ def _make_index(results: List[Dict]):
     return types.SimpleNamespace(
         papers=papers,
         get_topic_searcher=lambda: (embedder, table),
+        biblio_db=biblio_db,
     )
 
 
@@ -117,3 +139,41 @@ def test_with_text_false_token_cut_vs_with_text_true(index):
         f"with_text=False not significantly shorter: "
         f"{len(no_text)} vs {len(with_text)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# with_cites= (#88)
+# ---------------------------------------------------------------------------
+
+
+def test_with_cites_false_omits_cited_work_ids(index):
+    out = get_chunks_for_topic("query")
+    assert "cited_work_ids" not in out[0]
+
+
+def test_with_cites_true_attaches_parent_paper_citations(monkeypatch):
+    results = [{
+        "metadata": {"pdf_hash": "aaaaaaaaaaaa", "title": "Paper A",
+                     "year": 2005, "chunk_id": "c0",
+                     "section_class": "description", "headings": []},
+        "text": "body",
+        "_distance": 0.1,
+    }]
+    biblio = _FakeBiblioDB({"aaaaaaaaaaaa": [
+        "corpus:dunn|2005|x", "doi:10.1/abc",
+    ]})
+    fake = _make_index(results, biblio_db=biblio)
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    try:
+        out = get_chunks_for_topic("query", with_cites=True)
+        assert out[0]["cited_work_ids"] == ["corpus:dunn|2005|x", "doi:10.1/abc"]
+    finally:
+        mcp_app.set_index(original)
+
+
+def test_with_cites_true_empty_when_no_biblio_db(index):
+    # The `index` fixture has biblio_db=None — with_cites must degrade
+    # to an empty list rather than raising.
+    out = get_chunks_for_topic("query", with_cites=True)
+    assert out[0]["cited_work_ids"] == []


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** ([#88](https://github.com/caseywdunn/corpus/issues/88) Part 1).

## What
`get_chunks_for_topic` gains `with_cites: bool = False`. When `True`, each row gains `cited_work_ids` — the distinct works the chunk's **parent paper** cites in-text (from `biblio_authority`, deduplicated, loaded once per paper). Designed to feed straight into `format_citations`.

## Notes
- **Additive** — default behavior unchanged (no new field unless requested), so this is not a breaking default despite the plan's "breaking" tag. I kept it additive because the field only appears on opt-in; flag if you want it on by default instead.
- Granularity is **per parent paper**, not per chunk: in-text citations are paragraph-anchored with no chunk_id linkage (confirmed in `intext_citations`), so every chunk from the same paper carries the same list. Documented in the docstring + catalog.
- Degrades to `[]` when the authority DB isn't loaded (uses `getattr` so it's safe against minimal index stubs).

## Verification
- `tests/test_chunks_for_topic_with_text.py`: +3 tests (omitted by default, attached from a stub biblio_db in input order, empty when no biblio_db). **7 passed** locally. pyflakes clean.
- `dev_docs/MCP_TOOLS.md` row updated.

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)