### PR TITLE
mcp: search_taxon parent_chain (#88 Part 1)

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -34,7 +34,7 @@ for f in sorted(pathlib.Path('mcpsrv/tools').glob('*.py')):
 
 | Tool | Returns |
 | --- | --- |
-| `search_taxon` | Resolve a taxon name against the configured Darwin Core taxonomy snapshot. |
+| `search_taxon` | Resolve a taxon name against the configured Darwin Core taxonomy snapshot. Pass `parent_chain=True` (#88) to add the accepted taxon's ancestry (immediate parent → root, each `{taxon_id, scientific_name, rank}`). |
 | `get_papers_for_taxon` | Papers mentioning a taxon, resolved through synonymy. |
 | `get_chunks_for_taxon` | Every chunk that mentions the taxon (resolved through synonymy). |
 | `get_taxon_mentions` | All text-span mentions of a taxon across the corpus, with surrounding context. |

--- a/mcpsrv/tools/taxonomy.py
+++ b/mcpsrv/tools/taxonomy.py
@@ -36,8 +36,41 @@ def parse_chunk_index(chunk_id: str) -> int:
     return int(m.group(1)) if m else -1
 
 
+def _walk_parent_chain(conn, taxon_id: str, max_depth: int = 64) -> List[Dict]:
+    """Walk the DwC ``parent_name_usage_id`` tree upward from
+    ``taxon_id``, returning ancestors ordered immediate-parent → root,
+    each ``{taxon_id, scientific_name, rank}``. Cycle- and depth-guarded
+    against malformed snapshots."""
+    chain: List[Dict] = []
+    seen = {taxon_id}
+    current = taxon_id
+    for _ in range(max_depth):
+        row = conn.execute(
+            "SELECT parent_name_usage_id FROM taxa WHERE taxon_id = ?",
+            (current,),
+        ).fetchone()
+        parent_id = row[0] if row else None
+        if not parent_id or parent_id in seen:
+            break
+        seen.add(parent_id)
+        prow = conn.execute(
+            "SELECT taxon_id, scientific_name, taxon_rank "
+            "FROM taxa WHERE taxon_id = ?",
+            (parent_id,),
+        ).fetchone()
+        if not prow:
+            break
+        chain.append({
+            "taxon_id": prow[0],
+            "scientific_name": prow[1],
+            "rank": prow[2],
+        })
+        current = parent_id
+    return chain
+
+
 @mcp.tool()
-def search_taxon(name: str) -> Dict:
+def search_taxon(name: str, parent_chain: bool = False) -> Dict:
     """Resolve a taxon name against the configured DwC taxonomy snapshot.
 
     Accepts any form the snapshot knows: accepted names, historical
@@ -46,6 +79,12 @@ def search_taxon(name: str) -> Dict:
     the ``name_type`` of the match (``accepted`` | ``unaccepted`` |
     ``synonym``). Missing names return a structured ``not_found`` result
     rather than an error.
+
+    ``parent_chain=True`` (#88) adds a ``parent_chain`` list — the
+    accepted taxon's ancestors from immediate parent up to the root of
+    the snapshot, each ``{taxon_id, scientific_name, rank}`` — so a
+    caller can place the name in its higher classification without
+    extra calls.
     """
     idx = _need_index()
     if idx.taxonomy_db is None:
@@ -54,12 +93,17 @@ def search_taxon(name: str) -> Dict:
     if not hit:
         return {"not_found": True, "queried": name}
     in_corpus = hit["accepted_taxon_id"] in idx.taxon_to_papers
-    return {
+    result = {
         **hit,
         "queried": name,
         "in_corpus": in_corpus,
         "mentioning_paper_count": len(idx.taxon_to_papers.get(hit["accepted_taxon_id"], [])),
     }
+    if parent_chain:
+        result["parent_chain"] = _walk_parent_chain(
+            idx.taxonomy_db.conn, hit["accepted_taxon_id"],
+        )
+    return result
 
 
 @mcp.tool()

--- a/tests/test_search_taxon_parent_chain.py
+++ b/tests/test_search_taxon_parent_chain.py
@@ -1,0 +1,94 @@
+"""search_taxon parent_chain= ancestry walk (#88).
+
+parent_chain=True walks the DwC parent_name_usage_id tree upward and
+attaches the ancestor list (immediate parent → root). Additive: the
+field is absent unless requested. The walk is cycle- and depth-guarded
+so a malformed snapshot can't hang the tool.
+"""
+from __future__ import annotations
+
+import sqlite3
+import types
+
+import pytest
+
+from mcpsrv import app as mcp_app
+from mcpsrv.tools.taxonomy import search_taxon
+
+
+def _make_taxonomy_db(conn: sqlite3.Connection, lookups):
+    return types.SimpleNamespace(
+        conn=conn,
+        lookup=lambda name: lookups.get(name),
+    )
+
+
+@pytest.fixture
+def index():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        """CREATE TABLE taxa (
+             taxon_id TEXT PRIMARY KEY,
+             scientific_name TEXT,
+             taxon_rank TEXT,
+             parent_name_usage_id TEXT
+           )"""
+    )
+    # Apolemia uvaria → Apolemia → Apolemiidae → Siphonophorae (root).
+    rows = [
+        ("t:sipho", "Siphonophorae", "order", None),
+        ("t:apolfam", "Apolemiidae", "family", "t:sipho"),
+        ("t:apolemia", "Apolemia", "genus", "t:apolfam"),
+        ("t:uvaria", "Apolemia uvaria", "species", "t:apolemia"),
+        # A self-referential cycle, to exercise the guard.
+        ("t:cycle", "Cyclus badus", "species", "t:cycle"),
+    ]
+    conn.executemany("INSERT INTO taxa VALUES (?, ?, ?, ?)", rows)
+    conn.commit()
+
+    lookups = {
+        "Apolemia uvaria": {"accepted_taxon_id": "t:uvaria",
+                            "scientific_name": "Apolemia uvaria",
+                            "rank": "species", "name_type": "accepted"},
+        "Siphonophorae": {"accepted_taxon_id": "t:sipho",
+                          "scientific_name": "Siphonophorae",
+                          "rank": "order", "name_type": "accepted"},
+        "Cyclus badus": {"accepted_taxon_id": "t:cycle",
+                         "scientific_name": "Cyclus badus",
+                         "rank": "species", "name_type": "accepted"},
+    }
+    fake = types.SimpleNamespace(
+        taxonomy_db=_make_taxonomy_db(conn, lookups),
+        taxon_to_papers={"t:uvaria": ["h1"]},
+    )
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    yield fake
+    mcp_app.set_index(original)
+
+
+def test_parent_chain_omitted_by_default(index):
+    out = search_taxon("Apolemia uvaria")
+    assert "parent_chain" not in out
+
+
+def test_parent_chain_walks_immediate_parent_to_root(index):
+    out = search_taxon("Apolemia uvaria", parent_chain=True)
+    names = [a["scientific_name"] for a in out["parent_chain"]]
+    assert names == ["Apolemia", "Apolemiidae", "Siphonophorae"]
+    assert out["parent_chain"][0] == {
+        "taxon_id": "t:apolemia",
+        "scientific_name": "Apolemia",
+        "rank": "genus",
+    }
+
+
+def test_parent_chain_empty_at_root(index):
+    out = search_taxon("Siphonophorae", parent_chain=True)
+    assert out["parent_chain"] == []
+
+
+def test_parent_chain_cycle_is_guarded(index):
+    # Self-referential parent must not loop forever.
+    out = search_taxon("Cyclus badus", parent_chain=True)
+    assert out["parent_chain"] == []


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** ([#88](https://github.com/caseywdunn/corpus/issues/88) Part 1).

## What
`search_taxon` gains `parent_chain: bool = False`. When `True`, attaches `parent_chain` — the accepted taxon's ancestors (immediate parent → root), each `{taxon_id, scientific_name, rank}` — by walking the DwC `parent_name_usage_id` tree. Cycle- and depth-guarded (max_depth=64).

## Notes
- **Additive** (field absent unless requested) — enhancement-leaning Part-1 item, included per your "include both" decision.
- Uses the same `taxa` table columns the subtree dossier already walks.

## Verification
- New `tests/test_search_taxon_parent_chain.py` (4 tests): omitted by default, immediate-parent→root order, empty at root, self-cycle guarded. **4 passed** locally. pyflakes clean.
- `dev_docs/MCP_TOOLS.md` row updated.

Refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)