### PR TITLE
mcp: breadth + edge caps on get_citation_graph (#87)

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -51,7 +51,7 @@ for f in sorted(pathlib.Path('mcpsrv/tools').glob('*.py')):
 | `get_bibliography` | Parsed references for one paper (from Grobid TEI). |
 | `get_intext_citations` | In-text `<ref type="bibr">` markers for one paper, with deduplicated paragraph excerpts and section context. |
 | `get_excerpts_citing` | Cross-corpus: every passage citing a given work — surface text, section, and the surrounding paragraph. |
-| `get_citation_graph` | Citation graph around a work or paper (in / out / both). |
+| `get_citation_graph` | Citation graph around a work or paper (in / out / both). Bounded breadth (#87): `max_edges_per_node` (per-node fan-out, survivors ranked by `cited_by_count`) + `max_total_edges` caps, with a `truncated` flag. Generous defaults. |
 | `resolve_reference` | Resolve a free-text bibliographic reference to a work in the authority database. |
 | `format_citation` | Fully-assembled citation string for a work in the authority DB, plus provenance tier (`bib` / `grobid_reconciled` / `unresolved`) and verbatim warning footnote. The route for every citation an LLM client emits — never recombine fields client-side. |
 | `get_missing_references` | Works cited by corpus papers that are NOT in the corpus. |

--- a/mcpsrv/tools/bibliography.py
+++ b/mcpsrv/tools/bibliography.py
@@ -207,6 +207,8 @@ def get_citation_graph(
     paper_hash: Optional[str] = None,
     direction: str = "both",
     depth: int = 1,
+    max_edges_per_node: int = 50,
+    max_total_edges: int = 500,
 ) -> Dict:
     """Citation graph around a work.
 
@@ -216,7 +218,14 @@ def get_citation_graph(
     ``"cited_by"`` (papers cited by this work), or ``"both"``.
     ``depth > 1`` follows transitive citations (max 3).
 
-    Returns the root work plus the citation edges.
+    Breadth is bounded (#87) so a hub work can't return a runaway graph:
+    ``max_edges_per_node`` caps how many edges each node contributes
+    (when a node exceeds it, its edges are ranked by ``cited_by_count``
+    descending and the top ones kept), and ``max_total_edges`` caps the
+    whole walk. Defaults are generous; the response carries
+    ``truncated: bool`` so a caller can tell whether either cap fired.
+
+    Returns the root work plus the citation edges and ``truncated``.
     """
     idx = _need_index()
     if idx.biblio_db is None:
@@ -243,23 +252,43 @@ def get_citation_graph(
         },
     }
 
+    truncated = False
     if direction in ("citing", "both"):
-        citing = _walk_citations(idx.biblio_db, work_id, "citing", depth)
+        citing, t = _walk_citations(
+            idx.biblio_db, work_id, "citing", depth,
+            max_edges_per_node=max_edges_per_node,
+            max_total_edges=max_total_edges,
+        )
         result["citing"] = citing
+        truncated = truncated or t
     if direction in ("cited_by", "both"):
-        cited_by = _walk_citations(idx.biblio_db, work_id, "cited_by", depth)
+        cited_by, t = _walk_citations(
+            idx.biblio_db, work_id, "cited_by", depth,
+            max_edges_per_node=max_edges_per_node,
+            max_total_edges=max_total_edges,
+        )
         result["cited_by"] = cited_by
+        truncated = truncated or t
 
+    result["truncated"] = truncated
     return result
 
 
 def _walk_citations(
     biblio: BiblioAuthority, work_id: str, direction: str, depth: int,
-) -> List[Dict]:
-    """BFS citation walk."""
+    *, max_edges_per_node: int, max_total_edges: int,
+) -> "tuple[List[Dict], bool]":
+    """BFS citation walk with breadth + total-edge caps (#87).
+
+    Returns ``(edges, truncated)``. When a node has more neighbours than
+    ``max_edges_per_node`` they are ranked by ``cited_by_count`` (desc,
+    ``work_id`` tiebreak) and only the top ones kept — so the most-cited
+    edges survive truncation. The total walk stops at ``max_total_edges``.
+    """
     visited: set = set()
     frontier = [work_id]
     results: List[Dict] = []
+    truncated = False
     for d in range(depth):
         next_frontier: List[str] = []
         for wid in frontier:
@@ -267,13 +296,22 @@ def _walk_citations(
                 continue
             visited.add(wid)
             rows = biblio.citing(wid) if direction == "citing" else biblio.cited_by(wid)
+            if len(rows) > max_edges_per_node:
+                truncated = True
+                rows = sorted(
+                    rows,
+                    key=lambda r: (-biblio.citation_count(r["work_id"]),
+                                   r["work_id"]),
+                )[:max_edges_per_node]
             for r in rows:
+                if len(results) >= max_total_edges:
+                    return results, True
                 r["depth"] = d + 1
                 results.append(r)
                 if r["work_id"] not in visited:
                     next_frontier.append(r["work_id"])
         frontier = next_frontier
-    return results
+    return results, truncated
 
 
 @mcp.tool()

--- a/tests/test_citation_graph_caps.py
+++ b/tests/test_citation_graph_caps.py
@@ -1,0 +1,91 @@
+"""Breadth + total-edge caps on get_citation_graph (#87).
+
+A hub work (cited by hundreds) must not return a runaway graph.
+``max_edges_per_node`` caps per-node fan-out — ranking survivors by
+``cited_by_count`` so the most-cited edges are kept — and
+``max_total_edges`` caps the whole walk. ``truncated`` reports whether
+either fired. Defaults are generous, so the change is additive.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from mcpsrv import app as mcp_app
+from mcpsrv.tools.bibliography import get_citation_graph
+
+
+class _FakeBiblio:
+    def __init__(self, citing_edges, counts):
+        self._citing = citing_edges      # wid -> [neighbour work_ids]
+        self._counts = counts            # wid -> cited_by_count
+
+    def get_work(self, wid):
+        return {"work_id": wid, "title": wid} if wid in self._counts or True else None
+
+    def get_work_by_corpus_hash(self, _h):
+        return None
+
+    def get_authors(self, _wid):
+        return []
+
+    def citation_count(self, wid):
+        return self._counts.get(wid, 0)
+
+    def citing(self, wid):
+        return [{"work_id": n} for n in self._citing.get(wid, [])]
+
+    def cited_by(self, _wid):
+        return []
+
+
+def _set_index(biblio):
+    fake = types.SimpleNamespace(biblio_db=biblio)
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    return original
+
+
+@pytest.fixture(autouse=True)
+def _restore():
+    original = mcp_app._INDEX
+    yield
+    mcp_app.set_index(original)
+
+
+def test_no_truncation_under_caps():
+    biblio = _FakeBiblio(
+        {"root": ["a", "b", "c"]},
+        {"a": 10, "b": 5, "c": 1},
+    )
+    _set_index(biblio)
+    out = get_citation_graph(work_id="root", direction="citing", depth=1,
+                             max_edges_per_node=10)
+    assert out["truncated"] is False
+    assert {e["work_id"] for e in out["citing"]} == {"a", "b", "c"}
+
+
+def test_per_node_cap_keeps_most_cited():
+    biblio = _FakeBiblio(
+        {"root": ["a", "b", "c"]},
+        {"a": 10, "b": 5, "c": 1},
+    )
+    _set_index(biblio)
+    out = get_citation_graph(work_id="root", direction="citing", depth=1,
+                             max_edges_per_node=2)
+    assert out["truncated"] is True
+    # ranked by cited_by_count desc → a (10), b (5); c (1) dropped.
+    assert [e["work_id"] for e in out["citing"]] == ["a", "b"]
+
+
+def test_total_edge_cap_stops_walk():
+    biblio = _FakeBiblio(
+        {"root": ["a", "b", "c", "d", "e"]},
+        {k: 1 for k in "abcde"},
+    )
+    _set_index(biblio)
+    out = get_citation_graph(work_id="root", direction="citing", depth=1,
+                             max_edges_per_node=50, max_total_edges=3)
+    assert out["truncated"] is True
+    assert len(out["citing"]) == 3


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** ([#87](https://github.com/caseywdunn/corpus/issues/87)).

## What
`get_citation_graph` gains `max_edges_per_node` (default 50) and `max_total_edges` (default 500), plus a top-level `truncated: bool`. `_walk_citations` now returns `(edges, truncated)`; when a node exceeds the per-node cap its edges are ranked by `cited_by_count` (desc, `work_id` tiebreak) and the top ones kept — so the most-cited edges survive truncation — and the whole walk stops at `max_total_edges`.

## Notes
- **Additive** — generous defaults; existing callers see the same edges plus a `truncated` flag (almost always `False`).
- `citation_count` is only queried for ranking when a node actually overflows the per-node cap, so the common small-graph case pays nothing extra.

## Verification
- New `tests/test_citation_graph_caps.py` (3 tests): no truncation under caps; per-node cap keeps the most-cited; total-edge cap stops the walk. **3 passed** locally. pyflakes clean.
- `dev_docs/MCP_TOOLS.md` row updated.

Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)