### PR TITLE
pipeline: suppress HF implicit-token warning at entry (#97)

### DIFF
--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -70,6 +70,19 @@ _os.environ.setdefault("TORCH_COMPILE_DISABLE", "1")
 if _sys.platform == "darwin":
     _os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
+# HF_HUB_DISABLE_IMPLICIT_TOKEN=1 (#97): the three model-load sites
+# (SentenceTransformer in embeddings.py, AutoProcessor +
+# Qwen2_5_VL in vision.py) pull in huggingface_hub, which logs a noisy
+# warning when it falls back to an implicitly-stored token to fetch
+# public models we never gate. All our models are public, so disable the
+# implicit-token path. Must be set before huggingface_hub is imported —
+# the lazy `from sentence_transformers import …` / `from transformers
+# import …` inside those functions happens well after this package
+# __init__, so setting it here covers every code path (pipeline build +
+# the MCP serve path, which imports pipeline.embeddings). setdefault
+# leaves an explicit user override intact.
+_os.environ.setdefault("HF_HUB_DISABLE_IMPLICIT_TOKEN", "1")
+
 _log_level = _os.environ.get("CORPUS_LOG_LEVEL", "").upper()
 if _log_level in {"WARNING", "INFO", "DEBUG"}:
     _logging.basicConfig(

--- a/tests/test_hf_token_env.py
+++ b/tests/test_hf_token_env.py
@@ -1,0 +1,31 @@
+"""HF implicit-token warning suppressed at pipeline entry (#97).
+
+Importing the pipeline package must set HF_HUB_DISABLE_IMPLICIT_TOKEN
+before any submodule pulls in huggingface_hub, so the three model-load
+sites (embeddings.py, vision.py) don't emit the implicit-token warning
+for the public models we fetch. setdefault must also leave an explicit
+operator override intact.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+
+
+def test_importing_pipeline_sets_disable_implicit_token():
+    importlib.import_module("pipeline")  # import side effect under test
+    assert os.environ.get("HF_HUB_DISABLE_IMPLICIT_TOKEN") == "1"
+
+
+def test_explicit_override_is_preserved():
+    # In a clean subprocess with the var pre-set to 0, the setdefault in
+    # pipeline/__init__ must not clobber the operator's choice.
+    env = dict(os.environ, HF_HUB_DISABLE_IMPLICIT_TOKEN="0")
+    out = subprocess.run(
+        [sys.executable, "-c",
+         "import pipeline, os; print(os.environ['HF_HUB_DISABLE_IMPLICIT_TOKEN'])"],
+        env=env, capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "0"


### PR DESCRIPTION
**Group B fix** ([#97](https://github.com/caseywdunn/corpus/issues/97)).

Set `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` via `setdefault` in `pipeline/__init__.py`, next to the existing `TORCH_COMPILE_DISABLE` / `KMP_DUPLICATE_LIB_OK` defaults (#72) — the established "set once at package entry, before torch/HF import" pattern. This is the plan's "set once at pipeline entry" option rather than three call sites: `pipeline/__init__` runs before the lazy `from sentence_transformers import …` / `from transformers import …` inside the model-load functions, so it covers `embeddings.py` (SentenceTransformer) and `vision.py` (AutoProcessor + Qwen2_5_VL) for both the build and the MCP serve path (which imports `pipeline.embeddings`). `setdefault` preserves an explicit operator override.

Not a contract change.

## Verification
- New `tests/test_hf_token_env.py` (2 tests): importing `pipeline` sets the var; an explicit `=0` override survives (subprocess). **2 passed**. pyflakes clean.

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)