### PR TITLE
mcp: output-profile figure gate + caption preview (#101, #85)

### DIFF
--- a/dev_docs/LICENSING.md
+++ b/dev_docs/LICENSING.md
@@ -59,27 +59,39 @@ This file is a starting point, not legal advice. Operators
 publishing derived works are responsible for checking the rights
 that apply in their jurisdiction.
 
-## The publishable gate on `get_figure_image`
+## The figure-licensing gate, keyed to the output profile (#101)
 
-`mcpsrv.tools.figures.get_figure_image` raises a structured
-`ValueError` when `publishable=false`:
+The figure-licensing gate is governed by the active **output profile**,
+which a client passes per call as `profile=` (see `mcpsrv/profiles.py`):
 
-> figure not publishable: license='unknown' (source='unknown'). The
-> image is not returned to avoid downstream copyright issues. Read
-> get_figure(<paper_hash>, <figure_id>) for the raw license fields if
-> your jurisdiction / use case differs, or restart the server with
-> --allow-unpublishable for local rights-holder cases.
+- **`report`** (the default) — *permissive*: `get_figure_image` /
+  `get_figure_url` return the figure regardless of `publishable`, on the
+  basis that momentary in-chat display is fair use. License metadata is
+  still returned so a publication-bound client can self-filter.
+- **`manuscript`** / **`presentation`** — *strict*: the tools refuse a
+  figure whose parent work is `publishable=false`, e.g.
 
-The `--allow-unpublishable` server flag bypasses the gate
-unconditionally. Use only when:
+  > figure not publishable under profile 'manuscript': license='unknown'
+  > (source='unknown'). … Read get_figure(<paper_hash>, <figure_id>) for
+  > the raw license fields, or pass profile='report' for in-chat display.
 
-- You hold the rights to the figures (e.g. you authored the papers), **or**
-- You're operating under fair use / fair dealing for a specific purpose
-  and have made that determination yourself, **or**
-- The corpus runs strictly locally and no derived publication will
-  carry the figures.
+Selection is a **per-call client/session property**, not a server or
+corpus setting — a shared SSE server serves chat, internal-report, and
+manuscript sessions at once, so each call states its own profile. The
+server's `--default-profile` only sets the fallback for calls that omit
+`profile=` (default `report`); a startup warning fires when that
+fallback is permissive. When `get_figure_url` issues a URL it encodes
+the resolved profile into the URL, so the subsequent HTTP fetch enforces
+the same policy.
 
-Never set `--allow-unpublishable` on a public-facing deploy.
+> **Publication-bound work must pass `profile="manuscript"` per call.**
+> The permissive default means a client that forgets to set a profile
+> will receive uncleared figures — surface the returned `license` /
+> `publishable` fields and do not embed `publishable=false` figures in a
+> derived publication.
+
+(Replaces the v0.5 `--allow-unpublishable` server flag, which was a
+single global toggle and could not distinguish concurrent sessions.)
 
 ## Curating license fields
 

--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # MCP tool surface
 
-The MCP server exposes 39 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
+The MCP server exposes 41 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon,profiles}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
 
 This table is generated from the docstrings in the source; when the server definition changes, regenerate with:
 
@@ -62,13 +62,13 @@ for f in sorted(pathlib.Path('mcpsrv/tools').glob('*.py')):
 
 | Tool | Returns |
 | --- | --- |
-| `get_figures_for_taxon` | Figures from papers that mention the taxon, ranked by caption relevance. |
-| `get_figures_for_lexicon_term` | Figures whose captions mention a term from one lexicon category (anatomy, biogeography, …). |
+| `get_figures_for_taxon` | Figures from papers that mention the taxon, ranked by caption relevance. `caption_text` is a preview by default (#85); `full_caption=True` for the verbatim caption. |
+| `get_figures_for_lexicon_term` | Figures whose captions mention a term from one lexicon category (anatomy, biogeography, …). `caption_text` previewed by default (#85); `full_caption=True` for verbatim. |
 | `get_figure_dossier_for_taxon` | Figures linked to a taxon, each with `linked_chunks` (chunk IDs that reference the figure via `chunks.json:figure_refs`) + summarized ROIs. Single call replaces `get_figures_for_taxon` + per-figure `list_figure_rois` + cross-ref against `get_chunks_for_taxon`. |
 | `get_figure_dossier_for_term` | Same shape, for figures whose captions match a lexicon term. Category-agnostic. |
 | `get_figure` | One figure's full record: caption, page, bbox, image path, cross-references. |
-| `get_figure_image` | A figure (or panel crop) returned as inline PNG bytes. |
-| `get_figure_url` | A bearer-gated HTTP URL (plus `auth_header` + license fields) the caller can `curl -o` to land the figure PNG on disk without loading its bytes into the model's context — for pandoc / LaTeX / PDF assembly. |
+| `get_figure_image` | A figure (or panel crop) returned as inline PNG bytes. Figure-licensing gate keyed to the per-call `profile=` (#101): a strict profile (manuscript/presentation) refuses an unpublishable figure, the default `report` allows it. |
+| `get_figure_url` | A bearer-gated HTTP URL (plus `auth_header` + license/attribution fields) the caller can `curl -o` to land the figure PNG on disk without loading its bytes into context — for pandoc / LaTeX / PDF assembly. Honors the per-call `profile=` gate (#101) and encodes the resolved profile into the URL so the HTTP fetch enforces the same policy. |
 | `list_figure_rois` | Per-panel / per-subfigure ROIs annotated on a figure. |
 | `get_figure_roi_image` | Crop a panel ROI out of a figure image and return the crop's path. |
 
@@ -80,6 +80,15 @@ Requires `embed_chunks.py` to have been run (for `get_chunks_for_topic`) and `AN
 | --- | --- |
 | `get_chunks_for_topic` | Semantic search over chunks via the LanceDB vector index. Pass `with_text=False` for a metadata-only scan (#82): ~80 chars/row vs ~600 with full text, then drill down with `get_chunks(paper_hash, chunk_ids=[...])`. |
 | `translate_chunk` | Translate one chunk to the target language (default English), via the Anthropic Claude API. |
+
+## Output profiles
+
+Output type is a per-call client/session property (#101): pass `profile=` (`report` / `manuscript` / `presentation`) to the gated figure tools to select the figure-licensing policy. These tools expose the vocabulary.
+
+| Tool | Returns |
+| --- | --- |
+| `list_output_profiles` | The built-in output profiles and their policies (`figure_licensing`, `require_attribution`, `citation_provenance`, `excerpt_max_words`) plus the server's fallback `profile`. |
+| `get_active_profile` | The server's fallback output profile — the one applied to calls that omit `profile=`. Informational; the authoritative selection is per-call. |
 
 ## Lexicon
 
@@ -113,7 +122,7 @@ client.messages.create(
 Two breakpoints land below the ~5 k-token cache-eligibility floor on typical bundles:
 
 - **System prompt** (`mcpsrv/default_instructions.md` concatenated with any corpuscle-specific `instructions.md`): ~500–1500 tokens.
-- **Tool catalog** (39 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
+- **Tool catalog** (41 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
 
 Together ~5 k tokens get cached across all turns of a session — a non-trivial saving on conversations that fan out into many tool-use rounds. Cache lives ~5 minutes by default; subsequent sessions against the same build hit the same cache lines.
 

--- a/mcpsrv/figure_http.py
+++ b/mcpsrv/figure_http.py
@@ -22,9 +22,11 @@ local stdio (loopback HTTP server bound to 127.0.0.1) and SSE/AWS
 Honored gates:
 
 * ``_BearerAuthASGI`` (same middleware that guards ``/sse``).
-* ``#51`` publishable check (refuses figures the parent work isn't
-  licensed-cleared for, unless the server was started with
-  ``--allow-unpublishable``).
+* ``#51`` / ``#101`` figure-licensing check keyed to the request
+  ``?profile=`` (refuses figures the parent work isn't licensed-cleared
+  for under a *strict* profile; the permissive ``report`` default
+  allows them). The profile is encoded into the URL by
+  ``get_figure_url`` so the fetch enforces the same policy.
 """
 from __future__ import annotations
 
@@ -45,17 +47,25 @@ _HASH_RE = re.compile(r"^[a-f0-9]{12}$")
 _FIGURE_ID_RE = re.compile(r"^[A-Za-z0-9._\-]+$")
 
 
-def make_figure_app(idx, allow_unpublishable: bool = False):
+def make_figure_app(idx, default_profile: Optional[str] = None):
     """Build an ASGI handler that serves
-    ``GET /figures/<paper_hash>/<figure_id>?label=...``.
+    ``GET /figures/<paper_hash>/<figure_id>?profile=...&label=...``.
 
     ``idx`` is the live :class:`mcpsrv.indexes.CorpusIndex` so we can
     resolve ``paper_hash → hash_dir`` and probe the bibliographic
     authority for license fields.
+
+    The figure-licensing gate (#101) is keyed to the request's
+    ``?profile=`` (the value :func:`get_figure_url` encodes into the URL
+    it hands out), falling back to ``default_profile`` — the server's
+    ``--default-profile`` — when the query omits it. A strict client's
+    URL therefore stays strict on fetch; only an unprofiled URL falls
+    back to the server default.
     """
     # Lazy import — keeps the load-time cost off `import mcpsrv` for
     # non-serve uses (tests, bundle distillation).
     from .tools.figures import _license_metadata_for_paper
+    from .profiles import resolve_profile
 
     async def app(scope, receive, send):
         if scope.get("type") != "http":
@@ -83,8 +93,10 @@ def make_figure_app(idx, allow_unpublishable: bool = False):
             await _send_text(send, 400, "malformed figure_id")
             return
 
-        # Optional ``?label=<panel>`` to fetch a sub-panel crop.
+        # Optional ``?label=<panel>`` (sub-panel crop) and ``?profile=``
+        # (the policy the URL was issued under).
         label: Optional[str] = None
+        req_profile: Optional[str] = None
         qs = scope.get("query_string", b"").decode("latin-1", errors="replace")
         if qs:
             for piece in qs.split("&"):
@@ -93,24 +105,29 @@ def make_figure_app(idx, allow_unpublishable: bool = False):
                     if not _FIGURE_ID_RE.match(label):
                         await _send_text(send, 400, "malformed label")
                         return
+                elif piece.startswith("profile="):
+                    req_profile = piece[len("profile="):]
 
         p = idx.papers.get(paper_hash)
         if not p:
             await _send_text(send, 404, f"no such paper_hash: {paper_hash}")
             return
 
-        # Publishable gate (#51) — mirror the get_figure_image policy.
-        if not allow_unpublishable:
+        # Figure-licensing gate (#101) — keyed to the request profile,
+        # falling back to the server default. Mirrors get_figure_url.
+        active = resolve_profile(req_profile, default_profile)
+        if active.figure_licensing == "strict":
             lic = _license_metadata_for_paper(paper_hash)
             if not lic.get("publishable"):
                 body = {
                     "error": "figure not publishable",
+                    "profile": active.name,
                     "license": lic.get("license") or "unknown",
                     "license_source": lic.get("license_source"),
                     "hint": (
-                        "restart the server with --allow-unpublishable for "
-                        "local rights-holder cases, or read get_figure() for "
-                        "the raw license fields if your jurisdiction differs"
+                        "this URL was issued under a strict profile; request "
+                        "with profile=report for in-chat display, or read "
+                        "get_figure() for the raw license fields"
                     ),
                 }
                 await _send_json(send, 403, body)

--- a/mcpsrv/main.py
+++ b/mcpsrv/main.py
@@ -122,11 +122,14 @@ def main() -> int:
              "the port. Exits 0 on green, 3 on precondition failure. (#47)",
     )
     parser.add_argument(
-        "--allow-unpublishable", action="store_true",
-        help="Bypass the #51 publishable gate on get_figure_image — return "
-             "image bytes regardless of license / age. Use only for local "
-             "rights-holder cases (you own the figures, or you're operating "
-             "under fair use). Never set on a public-facing deploy.",
+        "--default-profile", choices=["report", "manuscript", "presentation"],
+        default="report",
+        help="Output profile (#101) applied to figure/citation calls that "
+             "omit profile=. Selection is really a per-call client property; "
+             "this is only the server fallback. 'report' (default) serves "
+             "figures permissively (in-chat display = fair use); 'manuscript'/"
+             "'presentation' gate on the publishable flag. Publication-bound "
+             "clients should pass profile='manuscript' per call regardless.",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
@@ -247,14 +250,18 @@ def main() -> int:
         taxon_mention_db=taxon_mention_db,
         embedding_model=args.embedding_model,
     )
-    # #51 — server-level allow-unpublishable override; carried on the
-    # index since that's what every figure tool already has access to.
-    index.allow_unpublishable = bool(args.allow_unpublishable)
-    if index.allow_unpublishable:
+    # #101 — server-level output-profile fallback for calls that omit
+    # profile=. Carried on the index, which every figure tool can read.
+    # The real selection is per-call; this is only the default.
+    from .profiles import get_profile
+    index.default_profile = args.default_profile
+    if get_profile(args.default_profile).figure_licensing == "permissive":
         logger.warning(
-            "*** --allow-unpublishable enabled: get_figure_image returns "
-            "bytes regardless of license. Use only for local rights-holder "
-            "cases; never on a public-facing deploy. ***",
+            "*** default profile %r serves figures permissively: a call "
+            "without profile= returns image bytes/URLs regardless of "
+            "license. This is the intended chat default; publication-bound "
+            "clients must pass profile='manuscript' per call. ***",
+            args.default_profile,
         )
     n = index.load()
     set_index(index)
@@ -267,7 +274,7 @@ def main() -> int:
         from .transport import start_stdio_figure_server
         try:
             fig_host, fig_port, fig_token = start_stdio_figure_server(
-                index, allow_unpublishable=index.allow_unpublishable,
+                index, default_profile=index.default_profile,
             )
             index.figure_url_base = f"http://{fig_host}:{fig_port}"
             index.figure_auth_token = fig_token
@@ -294,7 +301,7 @@ def main() -> int:
         _run_sse(
             args.host, args.port, token,
             idx=index,
-            allow_unpublishable=index.allow_unpublishable,
+            default_profile=index.default_profile,
         )
     else:  # argparse's choices= should prevent this
         raise ValueError(f"unknown transport: {args.transport!r}")

--- a/mcpsrv/profiles.py
+++ b/mcpsrv/profiles.py
@@ -1,0 +1,84 @@
+"""Output-type profiles (#101).
+
+Output type is a **client/session property carried per call, never a
+corpus or server attribute** — a shared SSE server fields many clients
+at once (chat, internal report, manuscript), so a server-start flag or a
+per-corpuscle config default cannot distinguish them. The vocabulary is
+a fixed set of global built-ins; selection is the per-call ``profile=``
+argument on the gated tools, with a server-level *fallback*
+(``--default-profile``) only for calls that omit it.
+
+Freeze-critical core (#101): the ``profile=`` parameter, this stable
+vocabulary, and the **figure-licensing** gate. The other policy axes are
+carried on the profile for forward-compatibility but their enforcement
+is additive and may land post-1.0:
+
+* ``require_attribution`` — surfaced in the figure-URL payload today;
+  full inline-emission is a follow-up.
+* ``citation_provenance`` — ``strict`` enforcement depends on #100.
+* ``excerpt_max_words`` — not yet enforced.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class OutputProfile:
+    name: str
+    figure_licensing: str          # "permissive" | "strict"
+    require_attribution: bool
+    citation_provenance: str       # "warn" | "strict"
+    excerpt_max_words: Optional[int]
+
+    def as_dict(self) -> Dict:
+        return {
+            "name": self.name,
+            "figure_licensing": self.figure_licensing,
+            "require_attribution": self.require_attribution,
+            "citation_provenance": self.citation_provenance,
+            "excerpt_max_words": self.excerpt_max_words,
+        }
+
+
+BUILTIN_PROFILES: Dict[str, OutputProfile] = {
+    "report": OutputProfile(
+        "report", "permissive", False, "warn", None),
+    "manuscript": OutputProfile(
+        "manuscript", "strict", True, "strict", 90),
+    "presentation": OutputProfile(
+        "presentation", "strict", True, "warn", None),
+}
+
+# Server fallback when a call omits profile=. Permissive by design (#94):
+# in-chat figure display is fair use, and refusing it is the common-case
+# pain. Publication-bound clients pass profile="manuscript" per call.
+DEFAULT_PROFILE = "report"
+
+
+def get_profile(name: Optional[str]) -> Optional[OutputProfile]:
+    """Return the named built-in profile, or None if unknown/None."""
+    if name is None:
+        return None
+    return BUILTIN_PROFILES.get(name)
+
+
+def resolve_profile(
+    per_call: Optional[str], server_default: Optional[str],
+) -> OutputProfile:
+    """Active profile: per-call wins, then the server default, then the
+    built-in ``report``. Unknown names fall through — callers validate
+    ``per_call`` up front (via :func:`get_profile`) for a clear error."""
+    for candidate in (per_call, server_default, DEFAULT_PROFILE):
+        prof = get_profile(candidate)
+        if prof is not None:
+            return prof
+    return BUILTIN_PROFILES[DEFAULT_PROFILE]
+
+
+def unknown_profile_error(name: str) -> Dict:
+    return {
+        "error": f"unknown profile {name!r}",
+        "available": sorted(BUILTIN_PROFILES),
+    }

--- a/mcpsrv/tools/__init__.py
+++ b/mcpsrv/tools/__init__.py
@@ -15,4 +15,5 @@ from . import (  # noqa: F401  (side-effect imports register MCP tools)
     chunks,
     bibliography,
     lexicon,
+    profiles,
 )

--- a/mcpsrv/tools/figures.py
+++ b/mcpsrv/tools/figures.py
@@ -5,13 +5,16 @@ get_figure, list_figure_rois, get_figure_roi_image, get_figure_image.
 The image-returning tools wrap PIL crops in FastMCP's ``Image``
 content type.
 
-#51 — figure licensing. Each figure inherits license metadata from
-its parent work (looked up at tool-call time from biblio_authority).
-``get_figure_image`` refuses image bytes when ``publishable=false``,
-returning a ValueError with the reason; clients with non-default
-jurisdictions can read the raw license fields and re-derive.
-``mcpsrv.main --allow-unpublishable`` bypasses for local rights-holder
-cases.
+#51 / #101 — figure licensing, keyed to the active output profile.
+Each figure inherits license metadata from its parent work (looked up
+at tool-call time from biblio_authority). The image-returning tools
+gate on the per-call ``profile=`` (``report`` / ``manuscript`` /
+``presentation``; see ``mcpsrv.profiles``): a ``strict`` profile refuses
+bytes/URL when ``publishable=false``, the default permissive ``report``
+allows them (in-chat display = fair use). The server ``--default-profile``
+sets the fallback for calls that omit ``profile=``. The raw license
+fields are always exposed via ``get_figure`` so a publication-bound
+client can self-filter.
 """
 from __future__ import annotations
 
@@ -21,6 +24,28 @@ from typing import Any, Dict, List, Optional, Union
 from mcp.server.fastmcp import Image
 
 from ..app import _load_json, _need_index, _validated_limit, mcp
+from ..profiles import get_profile, resolve_profile
+
+
+def _active_figure_profile(idx, profile: Optional[str]):
+    """Resolve the active output profile for a figure call (#101):
+    per-call ``profile=`` wins, else the server ``--default-profile``
+    fallback, else built-in ``report``."""
+    return resolve_profile(profile, getattr(idx, "default_profile", None))
+
+
+def _figure_licensing_refusal(active, lic: Dict) -> Optional[str]:
+    """Return a refusal reason when the active profile's figure-licensing
+    policy forbids this figure, else None. Only the ``strict`` policy
+    gates; ``permissive`` always allows (but the license metadata is
+    still surfaced so a publication-bound client can self-filter)."""
+    if active.figure_licensing == "strict" and not lic.get("publishable"):
+        return (
+            f"figure not publishable under profile {active.name!r}: "
+            f"license={lic.get('license') or 'unknown'!r} "
+            f"(source={lic.get('license_source')!r})"
+        )
+    return None
 
 
 # Restricted to the figure types that get returned by get_figures_for_*.
@@ -103,6 +128,7 @@ def get_figures_for_taxon(
     paper_hash: Optional[str] = None,
     limit: int = 50,
     include_all: bool = False,
+    full_caption: bool = False,
 ) -> List[Dict]:
     """Figures from papers that mention the taxon, ranked by caption
     relevance.
@@ -115,6 +141,9 @@ def get_figures_for_taxon(
     (skipping journal furniture, subpanels of already-returned figures,
     and unclassifiable graphical elements). Pass ``include_all=True`` to
     see every extracted item including the review bucket.
+
+    ``caption_text`` is a preview (first ~200 chars) by default (#85);
+    pass ``full_caption=True`` for the verbatim caption.
     """
     try:
         n = _validated_limit(limit)
@@ -143,7 +172,8 @@ def get_figures_for_taxon(
             ftype = f.get("figure_type")
             if not include_all and ftype not in _REAL_FIGURE_TYPES:
                 continue
-            caption = (f.get("caption_text") or f.get("caption") or "").lower()
+            cap_full = f.get("caption_text") or f.get("caption") or ""
+            caption = cap_full.lower()
             caption_hit = accepted_name_low in caption or (
                 matched_name_low and matched_name_low in caption
             )
@@ -153,7 +183,7 @@ def get_figures_for_taxon(
                 "figure_id": f.get("figure_id"),
                 "figure_type": ftype,
                 "page": f.get("page"),
-                "caption_text": f.get("caption_text") or f.get("caption"),
+                "caption_text": cap_full if full_caption else _caption_preview(cap_full),
                 "figure_number": f.get("figure_number"),
                 # Relative to the corpuscle's documents/ dir.
                 # Call get_figure_image to fetch bytes.
@@ -172,6 +202,7 @@ def get_figures_for_lexicon_term(
     paper_hash: Optional[str] = None,
     limit: int = 50,
     include_all: bool = False,
+    full_caption: bool = False,
 ) -> Union[List[Dict], Dict]:
     """Figures whose captions mention a lexicon term, ranked by
     caption occurrence count.
@@ -188,6 +219,9 @@ def get_figures_for_lexicon_term(
     figure captions; pass the canonical name or any declared synonym/
     translation. Returns real figures + plates by default;
     ``include_all=True`` includes the review bucket.
+
+    ``caption_text`` is a preview (first ~200 chars) by default (#85);
+    pass ``full_caption=True`` for the verbatim caption.
     """
     try:
         n = _validated_limit(limit)
@@ -237,7 +271,7 @@ def get_figures_for_lexicon_term(
                 "figure_type": ftype,
                 "page": f.get("page"),
                 "figure_number": f.get("figure_number"),
-                "caption_text": caption,
+                "caption_text": caption if full_caption else _caption_preview(caption),
                 # Relative to the corpuscle's documents/ dir.
                 # Call get_figure_image to fetch bytes.
                 "image_path": f"{h}/figures/{f.get('filename') or ''}",
@@ -652,6 +686,7 @@ def get_figure_image(
     paper_hash: str,
     figure_id: str,
     label: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> Image:
     """Return a figure (or panel crop) as inline PNG bytes.
 
@@ -661,35 +696,39 @@ def get_figure_image(
     panel crop, falling back to the whole figure when no pixel ROI was
     detected.
 
-    #51: refuses to return image bytes when the parent work's
-    ``publishable`` flag is false (license forbids reuse, or unknown
-    license, or work is too recent for the configured PD cutoff).
-    Override at server start with ``mcpsrv.main --allow-unpublishable``
-    for local-only rights-holder cases. The raw license fields are
-    always exposed via ``get_figure``, so clients with non-default
-    jurisdictions can re-derive.
+    #101: the figure-licensing gate is keyed to the active output
+    ``profile`` (``report`` / ``manuscript`` / ``presentation``; pass it
+    per call to reflect what you're producing). Under a ``strict``
+    profile (manuscript / presentation) this refuses image bytes when
+    the parent work's ``publishable`` flag is false. Under the default
+    permissive ``report`` profile the image is returned (in-chat display
+    is fair use). ``get_figure`` always exposes the raw license fields,
+    so a publication-bound client can self-filter; pass
+    ``profile="manuscript"`` to have the server enforce it. Unknown
+    profile names raise.
     """
     idx = _need_index()
     p = idx.papers.get(paper_hash)
     if not p:
         raise ValueError(f"no such paper_hash: {paper_hash}")
 
-    # #51 — publishable gate. Server-level allow override carried on the
-    # CorpusIndex. Refuses with a structured ValueError so clients
-    # can branch on the message.
-    if not getattr(idx, "allow_unpublishable", False):
-        lic = _license_metadata_for_paper(paper_hash)
-        if not lic["publishable"]:
-            license_v = lic.get("license") or "unknown"
-            raise ValueError(
-                f"figure not publishable: license={license_v!r} "
-                f"(source={lic['license_source']!r}). The image is not "
-                f"returned to avoid downstream copyright issues. Read "
-                f"get_figure({paper_hash!r}, {figure_id!r}) for the raw "
-                f"license fields if your jurisdiction / use case differs, "
-                f"or restart the server with --allow-unpublishable for "
-                f"local rights-holder cases."
-            )
+    if profile is not None and get_profile(profile) is None:
+        raise ValueError(
+            f"unknown profile {profile!r}; use list_output_profiles()"
+        )
+    active = _active_figure_profile(idx, profile)
+
+    # #101 — figure-licensing gate, keyed to the active profile. Refuses
+    # with a structured ValueError so clients can branch on the message.
+    lic = _license_metadata_for_paper(paper_hash)
+    refusal = _figure_licensing_refusal(active, lic)
+    if refusal:
+        raise ValueError(
+            f"{refusal}. The image is not returned to avoid downstream "
+            f"copyright issues. Read get_figure({paper_hash!r}, "
+            f"{figure_id!r}) for the raw license fields, or pass "
+            f"profile='report' for in-chat display."
+        )
 
     hash_dir = Path(p["hash_dir"])
     figs = _load_json(hash_dir / "figures.json", default={}) or {}
@@ -737,6 +776,7 @@ def get_figure_url(
     paper_hash: str,
     figure_id: str,
     label: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> Dict:
     """Return a bearer-gated HTTP URL the caller can ``curl -o`` to
     land the figure PNG on disk *without* loading its bytes into the
@@ -748,13 +788,23 @@ def get_figure_url(
     Fetch via ``curl -H "$auth_header" -o <path> "$url"``. Without
     ``label`` returns the whole figure; with ``label`` returns the
     panel crop if one exists (else falls back to the whole figure).
-    Refuses unpublishable figures (#51) unless server started with
-    ``--allow-unpublishable``.
 
-    Returns ``{url, auth_header, mime_type, publishable, license,
-    license_source}`` on success, ``{error: ...}`` on failure.
+    #101: the figure-licensing gate is keyed to the active ``profile``;
+    a ``strict`` profile (manuscript / presentation) refuses an
+    unpublishable figure, the default permissive ``report`` allows it.
+    The resolved profile is **encoded into the returned URL** so the
+    subsequent HTTP fetch enforces the same policy (otherwise a strict
+    client could leak via the unprofiled path).
+
+    Returns ``{url, auth_header, mime_type, profile, publishable,
+    license, license_source, attribution}`` on success, ``{error: ...}``
+    on failure (including ``unknown profile``).
     """
     idx = _need_index()
+    if profile is not None and get_profile(profile) is None:
+        from ..profiles import unknown_profile_error
+        return unknown_profile_error(profile)
+    active = _active_figure_profile(idx, profile)
     base = getattr(idx, "figure_url_base", None)
     if not base:
         return {
@@ -783,24 +833,28 @@ def get_figure_url(
         return {"error": f"no such figure_id {figure_id!r} in paper {paper_hash}"}
 
     lic = _license_metadata_for_paper(paper_hash)
-    if not getattr(idx, "allow_unpublishable", False) and not lic.get("publishable"):
+    refusal = _figure_licensing_refusal(active, lic)
+    if refusal:
         return {
             "error": (
-                f"figure not publishable: license={lic.get('license') or 'unknown'!r} "
-                f"(source={lic.get('license_source')!r}). Server refuses to hand out "
-                f"a URL the operator would only get a 403 from. Read "
-                f"get_figure({paper_hash!r}, {figure_id!r}) for the raw license "
-                f"fields, or restart the server with --allow-unpublishable for "
-                f"local rights-holder cases."
+                f"{refusal}. Server refuses to hand out a URL the operator "
+                f"would only get a 403 from. Read get_figure({paper_hash!r}, "
+                f"{figure_id!r}) for the raw license fields, or pass "
+                f"profile='report' for in-chat display."
             ),
+            "profile": active.name,
             **lic,
         }
 
-    url = f"{base}/figures/{paper_hash}/{figure_id}"
+    # Encode the resolved profile into the URL so the HTTP route enforces
+    # the same policy (the route defaults to the server fallback when no
+    # profile is present — a strict client must not leak via that path).
+    query = [f"profile={active.name}"]
     if label:
-        # Single key=value, no urlencoding gymnastics needed — figure_id
-        # / label are constrained to [A-Za-z0-9._-] on the server side.
-        url = f"{url}?label={label}"
+        # figure_id / label are constrained to [A-Za-z0-9._-] server-side,
+        # so no urlencoding gymnastics are needed.
+        query.append(f"label={label}")
+    url = f"{base}/figures/{paper_hash}/{figure_id}?{'&'.join(query)}"
     token = getattr(idx, "figure_auth_token", None)
     auth_header = f"Authorization: Bearer {token}" if token else None
 
@@ -808,9 +862,11 @@ def get_figure_url(
         "url": url,
         "auth_header": auth_header,
         "mime_type": "image/png",
+        "profile": active.name,
         "publishable": lic.get("publishable"),
         "license": lic.get("license"),
         "license_source": lic.get("license_source"),
+        "attribution": lic.get("attribution") if active.require_attribution else None,
         "fetch_hint": (
             "curl -fsSL -H \"$auth_header\" -o /tmp/fig.png \"$url\""
             if auth_header

--- a/mcpsrv/tools/profiles.py
+++ b/mcpsrv/tools/profiles.py
@@ -1,0 +1,50 @@
+"""Output-profile discovery tools (#101).
+
+The profile vocabulary lives in :mod:`mcpsrv.profiles`; these tools let
+a client enumerate it and read the server's fallback so it can decide
+which ``profile=`` to pass on the gated figure (and, later, citation)
+tools. Selection itself is per-call — these tools are read-only.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+from ..app import _need_index, mcp
+from ..profiles import BUILTIN_PROFILES, DEFAULT_PROFILE, resolve_profile
+
+
+@mcp.tool()
+def list_output_profiles() -> Dict:
+    """List the built-in output profiles (#101) and their policies.
+
+    An output profile is a client/session property you pass per call as
+    ``profile=`` to the gated tools (figure image/URL today). It governs
+    the figure-licensing gate: ``report`` (permissive — in-chat display)
+    vs ``manuscript`` / ``presentation`` (strict — only publishable
+    figures). Selection is per call, so concurrent sessions against the
+    same server can each use a different profile.
+
+    Returns ``{profiles: [{name, figure_licensing, require_attribution,
+    citation_provenance, excerpt_max_words}, ...], server_default}``.
+    """
+    idx = _need_index()
+    server_default = getattr(idx, "default_profile", None) or DEFAULT_PROFILE
+    return {
+        "profiles": [p.as_dict() for p in BUILTIN_PROFILES.values()],
+        "server_default": server_default,
+    }
+
+
+@mcp.tool()
+def get_active_profile() -> Dict:
+    """Return the server's fallback output profile — the one applied to
+    calls that omit ``profile=`` (#101).
+
+    This is informational: the authoritative selection is the per-call
+    ``profile=`` argument, so this reports the *default*, not a session
+    state. Returns the resolved profile's policy dict plus
+    ``is_server_default: true``.
+    """
+    idx = _need_index()
+    active = resolve_profile(None, getattr(idx, "default_profile", None))
+    return {**active.as_dict(), "is_server_default": True}

--- a/mcpsrv/transport.py
+++ b/mcpsrv/transport.py
@@ -161,7 +161,7 @@ def _run_sse(
     port: int,
     token: Optional[str],
     idx=None,
-    allow_unpublishable: bool = False,
+    default_profile: Optional[str] = None,
 ) -> None:
     """Serve the FastMCP app over SSE on ``host:port``, optionally
     with bearer-token auth.  Requires uvicorn (pulled in transitively
@@ -182,7 +182,7 @@ def _run_sse(
 
     sse_app = mcp.sse_app()
     if idx is not None:
-        figure_app = make_figure_app(idx, allow_unpublishable=allow_unpublishable)
+        figure_app = make_figure_app(idx, default_profile=default_profile)
         app = _RouteMuxASGI(sse_app, figure_app)
     else:
         app = sse_app
@@ -223,7 +223,7 @@ def _run_sse(
 
 def start_stdio_figure_server(
     idx,
-    allow_unpublishable: bool = False,
+    default_profile: Optional[str] = None,
     host: str = "127.0.0.1",
 ) -> Tuple[str, int, str]:
     """Spin up a daemon-thread uvicorn serving only the figure HTTP
@@ -249,7 +249,7 @@ def start_stdio_figure_server(
     sock.set_inheritable(True)
 
     token = secrets.token_hex(32)
-    figure_app = make_figure_app(idx, allow_unpublishable=allow_unpublishable)
+    figure_app = make_figure_app(idx, default_profile=default_profile)
     app = _BearerAuthASGI(figure_app, token)
 
     config = uvicorn.Config(

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -1253,7 +1253,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "                                 per-component DB overrides\n"
             "  --check                        non-binding pre-flight + exit\n"
             "  --name <id>                    server name reported to MCP clients\n"
-            "  --allow-unpublishable          bypass figure-licensing gate"
+            "  --default-profile <name>       fallback output profile for calls\n"
+            "                                 without profile= (report|manuscript|\n"
+            "                                 presentation; default report)"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/tests/test_figure_caption_preview.py
+++ b/tests/test_figure_caption_preview.py
@@ -1,0 +1,50 @@
+"""Caption preview default on the older figure-listing tools (#85).
+
+get_figures_for_taxon / get_figures_for_lexicon_term return a trimmed
+caption preview by default; full_caption=True restores the verbatim
+caption. Pins the token-cost contract for figure listings.
+"""
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from mcpsrv import app as mcp_app
+from mcpsrv.tools.figures import _FIGURE_CAPTION_PREVIEW_CHARS, get_figures_for_lexicon_term
+
+_LONG_CAPTION = "Figure 1. A nectophore " + ("blah " * 80) + "end."
+
+
+@pytest.fixture
+def index(tmp_path: Path):
+    h = "aaaaaaaaaaaa"
+    hash_dir = tmp_path / "documents" / h
+    hash_dir.mkdir(parents=True)
+    (hash_dir / "figures.json").write_text(json.dumps({"figures": [
+        {"figure_id": "docling_1", "filename": "fig_1.png",
+         "figure_type": "figure", "caption_text": _LONG_CAPTION},
+    ]}))
+    fake = types.SimpleNamespace(
+        papers={h: {"hash_dir": str(hash_dir), "title": "A paper"}},
+        lexicon_to_papers={"anatomy": {"nectophore": [h]}},
+    )
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    yield fake
+    mcp_app.set_index(original)
+
+
+def test_caption_is_previewed_by_default(index):
+    rows = get_figures_for_lexicon_term("anatomy", "nectophore")
+    cap = rows[0]["caption_text"]
+    assert cap != _LONG_CAPTION                  # trimmed
+    assert len(cap) <= _FIGURE_CAPTION_PREVIEW_CHARS + 1   # +1 for the ellipsis
+    assert cap.endswith("…")
+
+
+def test_full_caption_opt_in(index):
+    rows = get_figures_for_lexicon_term("anatomy", "nectophore", full_caption=True)
+    assert rows[0]["caption_text"] == _LONG_CAPTION

--- a/tests/test_output_profiles.py
+++ b/tests/test_output_profiles.py
@@ -1,0 +1,174 @@
+"""Output-profile figure-licensing gate (#101).
+
+The gate is keyed to the per-call ``profile=`` (client/session property)
+with a server ``--default-profile`` fallback. A ``strict`` profile
+(manuscript / presentation) refuses an unpublishable figure; the default
+permissive ``report`` allows it. The same index serving two calls with
+different ``profile=`` must yield independent outcomes — the core
+per-session regression for the shared-SSE deploy.
+"""
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+from PIL import Image as PILImage
+
+from mcpsrv import app as mcp_app
+from mcpsrv.profiles import BUILTIN_PROFILES, get_profile, resolve_profile
+from mcpsrv.tools.figures import get_figure_image, get_figure_url
+from mcpsrv.tools.profiles import get_active_profile, list_output_profiles
+
+
+class _StubBiblio:
+    def __init__(self, publishable: bool):
+        self._pub = publishable
+
+    def get_work_by_corpus_hash(self, _h):
+        return {
+            "publishable": 1 if self._pub else 0,
+            "license": "CC-BY-4.0" if self._pub else "unknown",
+            "license_source": "bibtex" if self._pub else "unknown",
+            "title": "A paper", "year": 2010,
+        }
+
+
+def _make_index(tmp_path: Path, *, publishable: bool, default_profile="report"):
+    h = "aaaaaaaaaaaa"
+    hash_dir = tmp_path / "documents" / h
+    (hash_dir / "figures").mkdir(parents=True)
+    PILImage.new("RGB", (4, 4), "white").save(hash_dir / "figures" / "fig_1.png")
+    (hash_dir / "figures.json").write_text(json.dumps({"figures": [
+        {"figure_id": "docling_1", "filename": "fig_1.png",
+         "figure_type": "figure", "caption_text": "Figure 1. A thing."},
+    ]}))
+    return types.SimpleNamespace(
+        papers={h: {"hash_dir": str(hash_dir), "title": "A paper"}},
+        biblio_db=_StubBiblio(publishable),
+        default_profile=default_profile,
+        figure_url_base="http://127.0.0.1:9999",
+        figure_auth_token="tok",
+    ), h
+
+
+@pytest.fixture(autouse=True)
+def _restore():
+    original = mcp_app._INDEX
+    yield
+    mcp_app.set_index(original)
+
+
+# --- profile vocabulary ----------------------------------------------------
+
+
+def test_builtin_vocabulary_and_resolution():
+    assert set(BUILTIN_PROFILES) == {"report", "manuscript", "presentation"}
+    assert BUILTIN_PROFILES["report"].figure_licensing == "permissive"
+    assert BUILTIN_PROFILES["manuscript"].figure_licensing == "strict"
+    # per-call wins; unknown falls through to server default then report.
+    assert resolve_profile("manuscript", "report").name == "manuscript"
+    assert resolve_profile(None, "manuscript").name == "manuscript"
+    assert resolve_profile(None, None).name == "report"
+    assert get_profile("nope") is None
+
+
+# --- get_figure_image gate -------------------------------------------------
+
+
+def test_strict_profile_refuses_unpublishable(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=False)
+    mcp_app.set_index(idx)
+    with pytest.raises(ValueError, match="not publishable under profile 'manuscript'"):
+        get_figure_image(h, "docling_1", profile="manuscript")
+
+
+def test_permissive_profile_allows_unpublishable(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=False)
+    mcp_app.set_index(idx)
+    img = get_figure_image(h, "docling_1", profile="report")
+    assert img is not None  # returned, not raised
+
+
+def test_default_fallback_is_permissive(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=False, default_profile="report")
+    mcp_app.set_index(idx)
+    assert get_figure_image(h, "docling_1") is not None  # no per-call profile
+
+
+def test_server_default_manuscript_gates_calls_without_profile(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=False, default_profile="manuscript")
+    mcp_app.set_index(idx)
+    with pytest.raises(ValueError, match="not publishable"):
+        get_figure_image(h, "docling_1")  # falls back to strict default
+
+
+def test_publishable_passes_strict(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=True)
+    mcp_app.set_index(idx)
+    assert get_figure_image(h, "docling_1", profile="manuscript") is not None
+
+
+def test_unknown_profile_raises(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=True)
+    mcp_app.set_index(idx)
+    with pytest.raises(ValueError, match="unknown profile"):
+        get_figure_image(h, "docling_1", profile="thesis")
+
+
+def test_per_call_profiles_are_independent_on_one_index(tmp_path):
+    # The shared-SSE invariant: same server/index, two sessions passing
+    # different profile= get independent gate outcomes.
+    idx, h = _make_index(tmp_path, publishable=False)
+    mcp_app.set_index(idx)
+    assert get_figure_image(h, "docling_1", profile="report") is not None
+    with pytest.raises(ValueError):
+        get_figure_image(h, "docling_1", profile="manuscript")
+
+
+# --- get_figure_url --------------------------------------------------------
+
+
+def test_url_carries_resolved_profile_and_gates(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=True)
+    mcp_app.set_index(idx)
+    out = get_figure_url(h, "docling_1", profile="manuscript")
+    assert out["profile"] == "manuscript"
+    assert "profile=manuscript" in out["url"]
+    assert out["attribution"] is not None or out["attribution"] is None  # field present
+
+
+def test_url_strict_refuses_unpublishable(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=False)
+    mcp_app.set_index(idx)
+    out = get_figure_url(h, "docling_1", profile="manuscript")
+    assert "not publishable" in out["error"]
+    assert "url" not in out
+
+
+def test_url_unknown_profile_error(tmp_path):
+    idx, h = _make_index(tmp_path, publishable=True)
+    mcp_app.set_index(idx)
+    out = get_figure_url(h, "docling_1", profile="thesis")
+    assert out["error"].startswith("unknown profile")
+
+
+# --- discovery tools -------------------------------------------------------
+
+
+def test_list_output_profiles(tmp_path):
+    idx, _ = _make_index(tmp_path, publishable=True, default_profile="report")
+    mcp_app.set_index(idx)
+    out = list_output_profiles()
+    assert out["server_default"] == "report"
+    names = {p["name"] for p in out["profiles"]}
+    assert names == {"report", "manuscript", "presentation"}
+
+
+def test_get_active_profile_reports_server_default(tmp_path):
+    idx, _ = _make_index(tmp_path, publishable=True, default_profile="manuscript")
+    mcp_app.set_index(idx)
+    out = get_active_profile()
+    assert out["name"] == "manuscript"
+    assert out["is_server_default"] is True


### PR DESCRIPTION
**Phase 1 of the v0.6 API-freeze pass** — the freeze-critical core of [#101](https://github.com/caseywdunn/corpus/issues/101) (supersedes #94) plus [#85](https://github.com/caseywdunn/corpus/issues/85), on one `figures.py` branch as the plan directs.

## #101 — output-profile figure-licensing gate
- New `mcpsrv/profiles.py`: global built-in vocabulary `report` / `manuscript` / `presentation`. **Output type is a per-call client/session property**, never a corpus/server attribute — a shared SSE server fields many document types at once.
- `get_figure_image` / `get_figure_url` / the HTTP route gate on a new per-call **`profile=`**: a *strict* profile (manuscript/presentation) refuses an unpublishable figure; the default permissive `report` allows it (in-chat display = fair use), while still returning the license fields so a publication client can self-filter.
- **`--allow-unpublishable` removed** → `--default-profile` server *fallback* (default `report`) for calls that omit `profile=`, with a permissive-default startup warning. The figure HTTP help in `corpus serve` and `dev_docs/LICENSING.md` are updated; LICENSING.md's guidance is inverted accordingly.
- `get_figure_url` **encodes the resolved profile into the URL** (`?profile=…`) so the subsequent HTTP fetch enforces the same policy (a strict client can't leak via the unprofiled path). Response gains `profile` + `attribution`.
- New discovery tools `list_output_profiles` / `get_active_profile` (surface **41** tools total).

## #85 — caption preview default
- `get_figures_for_taxon` / `get_figures_for_lexicon_term` return a ~200-char caption preview by default; `full_caption=True` restores verbatim.

## Breaking
`--allow-unpublishable` removed; figures served permissively when a call omits `profile=`; figure response shape gains `profile`/`attribution`. CHANGELOG migration note deferred to the consolidated Phase-3 entry.

## Deferred (additive, may follow post-1.0; per the plan)
`require_attribution` inline emission (the field is surfaced in the figure-URL payload today), `citation_provenance: strict` (depends on #100), `excerpt_max_words`, and `profile=` on the citation tools (additive optional param — also avoids conflicting with the unmerged #105).

## Verification
- New `tests/test_output_profiles.py` (13): vocabulary/resolution; strict-refuses vs permissive-allows; default fallback both ways; publishable passes strict; unknown-profile errors; **two profiles on one index yield independent outcomes** (the per-session regression); URL carries profile + gates; discovery tools.
- New `tests/test_figure_caption_preview.py` (2): preview default + `full_caption`.
- Full no-corpus suite **521 passed, 77 skipped** locally (`corpus` env). pyflakes: only pre-existing flags. 41 tools register.

Closes #85. Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)