### PR TITLE
#91: MCP health checks + refuse-to-serve on degraded capability

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -415,7 +415,7 @@ sudo journalctl -u corpus-mcp -f        # live server logs
 sudo journalctl -u nginx -f             # reverse-proxy logs
 sudo systemctl status corpus-mcp        # status + last few lines
 curl -s http://localhost/health         # nginx health (no host header needed)
-curl -s -H "Host: $DOMAIN" http://localhost/healthz   # MCP liveness
+curl -s -H "Host: $DOMAIN" http://localhost/healthz   # MCP capability report (JSON; 200 healthy / 503 degraded)
 ```
 
 ---
@@ -458,7 +458,13 @@ aws s3api delete-bucket --bucket $BUCKET --region $REGION
 - **Health check path is `/health`, not `/healthz`.**  nginx serves
   `/health` directly (no auth, returns `ok`); `/healthz` is proxied to
   the MCP server and requires the correct Host header.  ALB health checks
-  must use `/health`.
+  default to `/health` (pure process liveness).  `/healthz` is the
+  richer probe (#91): it returns a JSON capability report and **503 when
+  a backing index is degraded** (e.g. an embedding-model dim mismatch
+  that would otherwise serve silently-empty semantic searches).  Point
+  the ALB target group at `/healthz` instead of `/health` if you want a
+  degraded instance pulled from rotation rather than merely a crashed
+  one; `absent` capabilities (a structured-only corpus) stay healthy.
 
 - **`CreateBucket=false` for replacement deploys.**  When the S3 bucket
   already exists (owned by a previous stack that's still running), pass

--- a/dev_docs/clean_install_walkthrough.sh
+++ b/dev_docs/clean_install_walkthrough.sh
@@ -215,10 +215,13 @@ corpus serve -- \
     > serve.log 2>&1 &
 SERVE_PID=$!
 
-# Wait for the port. Probe /healthz (non-streaming, returns "ok"
-# immediately) — NOT /sse, which holds the connection open as a server-
-# sent-event stream and would hang `curl -sf` indefinitely without a
-# --max-time. Cap the loop at ~40s for cold-start index loading.
+# Wait for the port. Probe /healthz (non-streaming JSON capability
+# report, 200 when healthy / 503 when a capability is degraded — #91)
+# — NOT /sse, which holds the connection open as a server-sent-event
+# stream and would hang `curl -sf` indefinitely without a --max-time.
+# `curl -sf` treats the 503 as a failure, so the loop keeps waiting
+# until the server is actually serveable. Cap at ~40s for cold-start
+# index loading.
 for i in {1..40}; do
   curl -sf -o /dev/null --max-time 1 \
     "http://127.0.0.1:$MCP_PORT/healthz" && break

--- a/mcpsrv/indexes.py
+++ b/mcpsrv/indexes.py
@@ -63,6 +63,13 @@ class CorpusIndex:
         self._embedding_model_override = embedding_model
         self._embedder: Optional[EmbeddingBackend] = None
         self._lance_table = None
+        # Tracked semantic-search status (#91). ``None`` until first
+        # probed; thereafter one of ``"ok"`` / ``"absent"`` / a
+        # ``"degraded: <reason>"`` string. ``get_topic_searcher`` writes
+        # the authoritative value (it exercises the full embedder-load
+        # path); :meth:`capabilities` falls back to a cheap structural
+        # probe that doesn't force the ~600 MB embedder load.
+        self._topic_search_status: Optional[str] = None
 
         # Per-paper header, keyed on the 12-char short hash (directory name).
         self.papers: Dict[str, Dict] = {}
@@ -90,25 +97,37 @@ class CorpusIndex:
 
     def get_topic_searcher(self):
         """Return (embedder, table) for semantic chunk search, loading on
-        first use. Returns ``(None, None)`` if there is no LanceDB table
-        on disk — get_chunks_for_topic surfaces this as a clear error
-        rather than crashing.
+        first use. Returns ``(None, None)`` when semantic search is
+        unavailable, recording *why* on ``self._topic_search_status``
+        (#91) so :meth:`capabilities` and ``get_chunks_for_topic`` can
+        distinguish a legitimately structured-only corpus (``"absent"``)
+        from an operational fault (``"degraded: …"``) that should refuse
+        to serve rather than return empty rows.
         """
         if self._lance_table is not None and self._embedder is not None:
+            self._topic_search_status = "ok"
             return self._embedder, self._lance_table
+        # No vector store on disk → this corpus simply wasn't built with
+        # semantic search. Expected, not a fault.
+        if not self.vector_db_dir.exists():
+            self._topic_search_status = "absent"
+            return None, None
         try:
             import lancedb
         except ImportError:
-            return None, None
-        if not self.vector_db_dir.exists():
+            self._topic_search_status = "degraded: lancedb not installed"
             return None, None
         try:
             db = lancedb.connect(str(self.vector_db_dir))
             if "document_chunks" not in lancedb_table_names(db):
+                # vector_db/ exists but holds no chunk table — treat as
+                # absent (e.g. a leftover empty dir) rather than failing.
+                self._topic_search_status = "absent"
                 return None, None
             table = db.open_table("document_chunks")
         except Exception as e:
             logger.warning("Could not open LanceDB at %s: %s", self.vector_db_dir, e)
+            self._topic_search_status = "degraded: cannot open LanceDB index"
             return None, None
 
         # Pin the model to whatever was used to build the table — schema
@@ -118,6 +137,7 @@ class CorpusIndex:
             embedder = get_embedder(self._embedding_model_override)
         except EmbeddingError as e:
             logger.warning("Could not load embedding backend: %s", e)
+            self._topic_search_status = "degraded: embedding backend unavailable"
             return None, None
         if embedder.dim != existing_dim:
             logger.warning(
@@ -126,10 +146,107 @@ class CorpusIndex:
                 "matches the index.",
                 embedder.model_name, embedder.dim, existing_dim,
             )
+            self._topic_search_status = (
+                f"degraded: embedding-model dim mismatch "
+                f"(model emits {embedder.dim}, index expects {existing_dim})"
+            )
             return None, None
         self._embedder = embedder
         self._lance_table = table
+        self._topic_search_status = "ok"
         return embedder, table
+
+    def _probe_topic_search_cheap(self) -> str:
+        """Structural semantic-search probe that does *not* force the
+        embedder load (#91). Returns the same vocabulary as
+        ``self._topic_search_status`` but only catches faults visible
+        without loading the ~600 MB model: missing store, missing
+        lancedb, unopenable table. The embedder-load + dim-mismatch
+        faults are recorded by :meth:`get_topic_searcher` on the first
+        real query and take precedence once set.
+        """
+        if self._embedder is not None and self._lance_table is not None:
+            return "ok"
+        if not self.vector_db_dir.exists():
+            return "absent"
+        try:
+            import lancedb
+        except ImportError:
+            return "degraded: lancedb not installed"
+        try:
+            db = lancedb.connect(str(self.vector_db_dir))
+            if "document_chunks" not in lancedb_table_names(db):
+                return "absent"
+            db.open_table("document_chunks")
+        except Exception as e:
+            logger.warning("healthz: cannot open LanceDB at %s: %s",
+                           self.vector_db_dir, e)
+            return "degraded: cannot open LanceDB index"
+        return "ok"
+
+    def capabilities(self) -> Dict[str, Dict[str, Optional[str]]]:
+        """Snapshot of served-capability health (#91).
+
+        Each entry is ``{"state": <state>, "detail": <str|None>}`` where
+        ``state`` is:
+
+        * ``"ok"`` — backing index loaded and serving.
+        * ``"absent"`` — legitimately not part of this corpus
+          (structured-only build, no taxon-mention layer, …). Not a
+          fault; tools return their usual "not configured" guidance.
+        * ``"degraded"`` — the index exists but cannot be served
+          (misconfiguration / corruption). An operational fault:
+          ``/healthz`` returns non-200 and the backed tools raise hard
+          errors instead of returning empty rows.
+
+        Detail strings are kept filesystem-path-free so ``/healthz`` can
+        expose them unauthenticated; full exception text goes to the log.
+        """
+        caps: Dict[str, Dict[str, Optional[str]]] = {}
+
+        # Core: an empty paper index means a broken / empty bundle
+        # (the v0.5 zero-yield failure mode) — degraded, not absent.
+        caps["papers"] = (
+            {"state": "ok", "detail": f"{len(self.papers)} papers"}
+            if self.papers
+            else {"state": "degraded", "detail": "no papers indexed"}
+        )
+
+        # Semantic search: prefer the authoritative status recorded by a
+        # real query; otherwise do the cheap structural probe.
+        raw = self._topic_search_status or self._probe_topic_search_cheap()
+        if raw == "ok":
+            caps["topic_search"] = {"state": "ok", "detail": None}
+        elif raw == "absent":
+            caps["topic_search"] = {
+                "state": "absent",
+                "detail": "no semantic-search index in this corpus",
+            }
+        else:
+            caps["topic_search"] = {
+                "state": "degraded",
+                "detail": raw.split("degraded: ", 1)[-1],
+            }
+
+        # Structured backings: loaded, or legitimately not configured.
+        for name, db in (
+            ("taxonomy", self.taxonomy_db),
+            ("bibliography", self.biblio_db),
+            ("taxon_mentions", self.taxon_mention_db),
+        ):
+            caps[name] = (
+                {"state": "ok", "detail": None}
+                if db is not None
+                else {"state": "absent", "detail": "not configured for this corpus"}
+            )
+        return caps
+
+    def is_healthy(self) -> bool:
+        """True iff no capability is ``degraded`` (#91). ``absent`` is
+        healthy — a structured-only corpus is a valid deploy."""
+        return not any(
+            c["state"] == "degraded" for c in self.capabilities().values()
+        )
 
     def load(self) -> int:
         """Populate the indexes from ``documents/*/``. Returns the number

--- a/mcpsrv/main.py
+++ b/mcpsrv/main.py
@@ -267,6 +267,25 @@ def main() -> int:
     set_index(index)
     logger.info("Serving corpus: %s (%d papers)", args.output_dir, n)
 
+    # #91 — surface capability health at startup. Degraded capabilities
+    # (index present but unserveable) get a loud warning; they also make
+    # /healthz return 503 and the backed tools raise hard errors rather
+    # than returning empty rows. ``absent`` is normal (structured-only
+    # corpus) and logged at info level only.
+    caps = index.capabilities()
+    degraded = {k: c["detail"] for k, c in caps.items() if c["state"] == "degraded"}
+    if degraded:
+        logger.warning(
+            "*** Serving with DEGRADED capabilities: %s. /healthz will "
+            "report 503 and the backed tools will refuse to serve. ***",
+            ", ".join(f"{k} ({d})" for k, d in degraded.items()),
+        )
+    else:
+        logger.info(
+            "Capabilities: %s",
+            ", ".join(f"{k}={c['state']}" for k, c in caps.items()),
+        )
+
     if args.transport == "stdio":
         # #69 — start the figure HTTP side-car so get_figure_url can
         # return a working URL on local stdio MCP. Daemon thread; dies

--- a/mcpsrv/tools/chunks.py
+++ b/mcpsrv/tools/chunks.py
@@ -274,6 +274,16 @@ def get_chunks_for_topic(
     idx = _need_index()
     embedder, table = idx.get_topic_searcher()
     if embedder is None or table is None:
+        # #91 — distinguish a legitimately structured-only corpus
+        # (return the build-an-index guidance) from an operational
+        # fault (raise a hard MCP error so a degraded server refuses to
+        # serve silently-empty results that read as "no matches").
+        cap = idx.capabilities()["topic_search"]
+        if cap["state"] == "degraded":
+            raise RuntimeError(
+                f"topic search is degraded and refusing to serve: "
+                f"{cap['detail']}. Check the server logs and GET /healthz."
+            )
         return [{
             "error": "no LanceDB index available; run "
                      "`python embed_chunks.py <output_dir>` to build one"

--- a/mcpsrv/transport.py
+++ b/mcpsrv/transport.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import hmac
+import json
 import logging
 import os
 import secrets
@@ -30,18 +31,43 @@ logger = logging.getLogger(__name__)
 
 
 class _HealthzASGI:
-    """ASGI middleware: short-circuit ``GET /healthz`` with a plain
-    200, delegate everything else.
+    """ASGI middleware: short-circuit ``GET /healthz`` with a JSON
+    capability report, delegate everything else.
 
     Mounted *outside* :class:`_BearerAuthASGI` so the probe is reachable
-    without a bearer token.  ``/healthz`` reveals only that the process
-    is up, which is already inferable from a successful TCP connect,
-    and uptime monitors / nginx readiness probes should not need the
-    shared secret.
+    without a bearer token — uptime monitors / ALB readiness probes
+    should not need the shared secret. The body reports per-capability
+    state (#91); detail strings are kept filesystem-path-free so this
+    stays safe to expose unauthenticated.
+
+    Status code is **200** when every capability is ``ok`` or ``absent``
+    and **503** when any capability is ``degraded`` — so a load balancer
+    pulls a server whose backing index broke (e.g. an embedding-model
+    dim mismatch) out of rotation instead of serving silently-empty
+    semantic searches.
     """
 
-    def __init__(self, app):
+    def __init__(self, app, idx=None):
         self.app = app
+        self.idx = idx
+
+    def _report(self) -> Tuple[int, dict]:
+        from .app import TOOL_STATS
+        if self.idx is None:
+            # No index wired (shouldn't happen in SSE serve) — process
+            # is up but can't report capabilities.
+            return 200, {"status": "ok", "capabilities": {}, "tools": {}}
+        caps = self.idx.capabilities()
+        healthy = not any(c["state"] == "degraded" for c in caps.values())
+        body = {
+            "status": "ok" if healthy else "degraded",
+            "capabilities": caps,
+            "tools": {
+                "total_calls": TOOL_STATS.total_calls,
+                "total_errors": TOOL_STATS.total_errors,
+            },
+        }
+        return (200 if healthy else 503), body
 
     async def __call__(self, scope, receive, send):
         if (
@@ -49,12 +75,14 @@ class _HealthzASGI:
             and scope.get("method") == "GET"
             and scope.get("path") == "/healthz"
         ):
+            status, body = self._report()
+            payload = (json.dumps(body) + "\n").encode("utf-8")
             await send({
                 "type": "http.response.start",
-                "status": 200,
-                "headers": [(b"content-type", b"text/plain; charset=utf-8")],
+                "status": status,
+                "headers": [(b"content-type", b"application/json; charset=utf-8")],
             })
-            await send({"type": "http.response.body", "body": b"ok\n"})
+            await send({"type": "http.response.body", "body": payload})
             return
         await self.app(scope, receive, send)
 
@@ -197,7 +225,7 @@ def _run_sse(
             host, port,
         )
     # Healthz wraps the auth layer so probes don't need the bearer token.
-    app = _HealthzASGI(app)
+    app = _HealthzASGI(app, idx=idx)
     logger.info("Serving SSE on http://%s:%d (healthz: GET /healthz)", host, port)
     if idx is not None:
         logger.info(

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,216 @@
+"""Health-check + degraded-capability tests (#91).
+
+Three layers:
+
+* :meth:`CorpusIndex.capabilities` classifies each backing index as
+  ``ok`` / ``absent`` / ``degraded`` — the single source of truth.
+* ``_HealthzASGI`` turns that into a JSON body + a 200/503 status so a
+  load balancer pulls a degraded server out of rotation.
+* ``get_chunks_for_topic`` raises a hard MCP error (not an empty
+  ``[{error: …}]`` row) when its backing semantic index is degraded.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from mcpsrv.indexes import CorpusIndex
+from mcpsrv.transport import _HealthzASGI
+
+
+# ---------------------------------------------------------------------------
+# capabilities() classification
+# ---------------------------------------------------------------------------
+
+
+def _bare_index(tmp_path: Path) -> CorpusIndex:
+    """A CorpusIndex over an empty output dir — no documents, no
+    vector store, no structured DBs. Avoids load() (which needs a
+    documents/ tree) by constructing directly."""
+    return CorpusIndex(tmp_path)
+
+
+def test_structured_only_corpus_is_healthy(tmp_path):
+    """No vector store + no structured DBs is a valid deploy: every
+    optional capability is ``absent`` (not ``degraded``), so the server
+    is healthy. The one exception is ``papers`` — see below."""
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}  # one paper → core ok
+    caps = idx.capabilities()
+
+    assert caps["topic_search"]["state"] == "absent"
+    assert caps["taxonomy"]["state"] == "absent"
+    assert caps["bibliography"]["state"] == "absent"
+    assert caps["taxon_mentions"]["state"] == "absent"
+    assert caps["papers"]["state"] == "ok"
+    assert idx.is_healthy() is True
+
+
+def test_empty_paper_index_is_degraded(tmp_path):
+    """An empty paper index is the v0.5 zero-yield failure mode — a
+    broken bundle, not a valid structured-only corpus. Degraded."""
+    idx = _bare_index(tmp_path)
+    assert idx.papers == {}
+    caps = idx.capabilities()
+    assert caps["papers"]["state"] == "degraded"
+    assert idx.is_healthy() is False
+
+
+def test_structured_dbs_report_ok_when_loaded(tmp_path):
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    idx.taxonomy_db = object()
+    idx.biblio_db = object()
+    idx.taxon_mention_db = object()
+    caps = idx.capabilities()
+    assert caps["taxonomy"]["state"] == "ok"
+    assert caps["bibliography"]["state"] == "ok"
+    assert caps["taxon_mentions"]["state"] == "ok"
+
+
+def test_recorded_degraded_status_takes_precedence(tmp_path):
+    """Once a real query records a degraded reason (e.g. an embedding-
+    model dim mismatch only detectable by loading the model),
+    capabilities() must report it rather than re-running the cheap
+    structural probe that can't see it."""
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    idx._topic_search_status = (
+        "degraded: embedding-model dim mismatch (model emits 768, index expects 1024)"
+    )
+    caps = idx.capabilities()
+    assert caps["topic_search"]["state"] == "degraded"
+    assert "dim mismatch" in caps["topic_search"]["detail"]
+    # detail is path-free (safe for unauthenticated /healthz)
+    assert "/" not in caps["topic_search"]["detail"]
+    assert idx.is_healthy() is False
+
+
+def test_missing_vector_store_probes_absent_without_loading_embedder(tmp_path):
+    """The cheap structural probe must not force the ~600 MB embedder
+    load: a missing vector_db/ resolves to ``absent`` with the embedder
+    untouched."""
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    assert idx.capabilities()["topic_search"]["state"] == "absent"
+    assert idx._embedder is None  # never loaded
+
+
+# ---------------------------------------------------------------------------
+# _HealthzASGI status code + JSON body
+# ---------------------------------------------------------------------------
+
+
+def _probe_healthz(idx) -> tuple[int, dict]:
+    """Drive _HealthzASGI through a GET /healthz scope, capturing the
+    response status + decoded JSON body."""
+    app = _HealthzASGI(app=_unreachable_app, idx=idx)
+    sent: list[dict] = []
+
+    async def send(msg):
+        sent.append(msg)
+
+    async def receive():  # pragma: no cover - not used by the healthz path
+        return {"type": "http.request"}
+
+    scope = {"type": "http", "method": "GET", "path": "/healthz"}
+    asyncio.run(app(scope, receive, send))
+
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    body_msg = next(m for m in sent if m["type"] == "http.response.body")
+    return start["status"], json.loads(body_msg["body"])
+
+
+async def _unreachable_app(scope, receive, send):  # pragma: no cover
+    raise AssertionError("/healthz must short-circuit before delegating")
+
+
+def test_healthz_returns_200_when_healthy(tmp_path):
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    status, body = _probe_healthz(idx)
+    assert status == 200
+    assert body["status"] == "ok"
+    assert body["capabilities"]["papers"]["state"] == "ok"
+    assert "tools" in body and "total_calls" in body["tools"]
+
+
+def test_healthz_returns_503_when_degraded(tmp_path):
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    idx._topic_search_status = "degraded: cannot open LanceDB index"
+    status, body = _probe_healthz(idx)
+    assert status == 503
+    assert body["status"] == "degraded"
+    assert body["capabilities"]["topic_search"]["state"] == "degraded"
+
+
+def test_healthz_delegates_non_probe_paths(tmp_path):
+    """A non-/healthz request must fall through to the wrapped app."""
+    idx = _bare_index(tmp_path)
+    delegated = {"hit": False}
+
+    async def downstream(scope, receive, send):
+        delegated["hit"] = True
+
+    app = _HealthzASGI(app=downstream, idx=idx)
+    asyncio.run(app({"type": "http", "method": "GET", "path": "/sse"},
+                    None, None))
+    assert delegated["hit"] is True
+
+
+# ---------------------------------------------------------------------------
+# get_chunks_for_topic: hard error on degraded, friendly row on absent
+# ---------------------------------------------------------------------------
+
+
+def _inject(idx):
+    from mcpsrv import app as mcp_app
+    original = mcp_app._INDEX
+    mcp_app.set_index(idx)
+    return original
+
+
+def test_topic_search_absent_returns_build_index_row(tmp_path):
+    """Structured-only corpus: a clear, non-raising guidance row."""
+    from mcpsrv import app as mcp_app
+    from mcpsrv.tools.chunks import get_chunks_for_topic
+
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+    original = _inject(idx)
+    try:
+        out = get_chunks_for_topic(query="anything")
+        assert isinstance(out, list)
+        assert "no LanceDB index available" in out[0]["error"]
+    finally:
+        mcp_app.set_index(original)
+
+
+def test_topic_search_degraded_raises_hard_error(tmp_path):
+    """Operational fault: refuse to serve with a raised error rather
+    than returning empty rows that read as 'no matches'."""
+    from mcpsrv import app as mcp_app
+    from mcpsrv.tools.chunks import get_chunks_for_topic
+
+    idx = _bare_index(tmp_path)
+    idx.papers = {"deadbeef0000": {"title": "x"}}
+
+    # Mimic a real degraded probe: get_topic_searcher records the
+    # reason and returns (None, None). (Setting the status directly
+    # wouldn't survive, since get_chunks_for_topic re-probes first.)
+    def _degraded_searcher():
+        idx._topic_search_status = "degraded: embedding backend unavailable"
+        return None, None
+
+    idx.get_topic_searcher = _degraded_searcher
+    original = _inject(idx)
+    try:
+        with pytest.raises(RuntimeError, match="degraded and refusing to serve"):
+            get_chunks_for_topic(query="anything")
+    finally:
+        mcp_app.set_index(original)


### PR DESCRIPTION
Group-C ops item from `dev_docs/PLAN.md`. Turns the silent `(None, None)` degradation in `get_topic_searcher` into a tracked capability model surfaced at three layers, consuming the Phase-0 instrumentation shim already on `dev`.

## Capability model (`mcpsrv/indexes.py`)
`get_topic_searcher` now records **why** semantic search is unavailable on `self._topic_search_status`, distinguishing two fundamentally different situations:

| State | Meaning | /healthz | Tool behavior |
| --- | --- | --- | --- |
| `ok` | index loaded and serving | 200 | normal |
| `absent` | not part of this corpus (structured-only build, no vector store, DB not configured) | 200 | friendly "build an index" row / "not configured" |
| `degraded` | index present but **unserveable** (missing lancedb, unopenable table, embedder-load failure, embedding-model dim mismatch, **zero papers**) | **503** | **hard MCP error** |

New `capabilities()` classifies `papers` / `topic_search` / `taxonomy` / `bibliography` / `taxon_mentions`. A cheap structural probe (`_probe_topic_search_cheap`) keeps `/healthz` from forcing the ~600 MB embedder load; a reason recorded by a real query (the only way to see a dim mismatch) takes precedence. Detail strings are filesystem-path-free so the unauthenticated probe is safe to expose.

## /healthz (`mcpsrv/transport.py`)
`_HealthzASGI` returns a JSON body — `{status, capabilities, tools}` — and **503 when any capability is degraded**, 200 otherwise. Includes the Phase-0 `TOOL_STATS` call/error totals. Still mounted outside auth.

## Refuse-to-serve (`mcpsrv/tools/chunks.py`)
`get_chunks_for_topic` raises a `RuntimeError` (→ JSON-RPC error) when topic search is degraded, rather than returning an empty `[{error}]` row that an LLM reads as "no matches". Keeps the non-raising guidance row when the index is merely absent.

## Startup (`mcpsrv/main.py`)
Logs capability states; a loud warning lists any degraded ones.

## Docs
`DEPLOY.md` — point the ALB target group at `/healthz` (not `/health`) for capability-aware rotation; `absent` stays healthy. Clean-install walkthrough comments updated.

## Tests
New `tests/test_healthz.py` (10 tests): capability classification (absent vs degraded vs ok, empty-index degraded, recorded-status precedence, no-embedder-load probe), `_HealthzASGI` 200/503 + JSON body + delegation, and `get_chunks_for_topic` hard-error-on-degraded / friendly-row-on-absent. Full local suite: **558 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)