### PR TITLE
#90: central per-invocation run log

### DIFF
--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -44,6 +44,7 @@ import os
 import shutil
 import subprocess
 import sys
+import textwrap
 from importlib import resources
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -486,7 +487,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
             status="ok",
         )
     else:
-        run_log = _write_run_log(output_dir)
+        run_log = _write_run_log(output_dir, cfg=cfg, argv=sys.argv)
         if run_log is None:
             print_status(
                 "run complete. Try `corpus status --report` and `corpus serve` next.",
@@ -501,18 +502,31 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
-def _write_run_log(output_dir: Path) -> Optional[Path]:
-    """Write the end-of-run report to ``<output_dir>/run.log`` (#57).
+def _write_run_log(
+    output_dir: Path,
+    cfg: Optional[CorpuscleConfig] = None,
+    argv: Optional[List[str]] = None,
+) -> Optional[Path]:
+    """Write the end-of-run report (#57, #90).
 
-    Captures the same content as ``corpus status --report`` so the
-    operator has a self-contained record of pass-rates and cross-paper
-    artifact presence for this run. Overwrites prior log — the state
-    reported is always "as of right now"; for history, git the file
-    or copy it aside.
+    Captures a self-contained, reproducible record of the run: the
+    ``corpus status --report`` pass-rate + artifact rollup, plus (#90)
+    the invocation's argv, the *resolved* config, the dependency-stack
+    versions that produced the output, and aggregate stage success /
+    failure counts.
 
-    Returns the written path, or ``None`` if there's nothing to
-    report (no ``documents/`` tree yet — e.g. the orchestrator
-    bailed before extract ran).
+    Two copies are written:
+
+    * ``<output_dir>/runs/<timestamp>/run.log`` — the per-invocation
+      archive, so a sequence of runs leaves an auditable trail rather
+      than overwriting one another.
+    * ``<output_dir>/run.log`` — the "latest" copy, preserved at the
+      top level for #57 back-compat (``corpus status``, the served
+      bundle, and existing tooling read it there).
+
+    Returns the top-level path, or ``None`` if there's nothing to
+    report (no ``documents/`` tree yet — e.g. the orchestrator bailed
+    before extract ran).
     """
     from datetime import datetime
     from .status import aggregate, render_artifacts, render_text
@@ -521,16 +535,83 @@ def _write_run_log(output_dir: Path) -> Optional[Path]:
     if not documents_dir.is_dir():
         return None
     rollup = aggregate(documents_dir)
-    header = (
-        f"# corpus run report\n"
-        f"# generated at {datetime.now().isoformat(timespec='seconds')}\n"
-        f"# corpus version {__version__}\n"
-        f"# output_dir {output_dir.resolve()}\n\n"
-    )
-    body = render_text(rollup) + "\n\n" + render_artifacts(output_dir)
+
+    now = datetime.now()
+    header_lines = [
+        "# corpus run report",
+        f"# generated at {now.isoformat(timespec='seconds')}",
+        f"# corpus version {__version__}",
+    ]
+    sha = _git_sha_or_none()
+    if sha:
+        header_lines.append(f"# git {sha}")
+    header_lines.append(f"# output_dir {output_dir.resolve()}")
+    if argv is not None:
+        header_lines.append(f"# argv {' '.join(argv)}")
+    header = "\n".join(header_lines) + "\n\n"
+
+    sections = [render_text(rollup), _render_run_summary(rollup)]
+    if cfg is not None:
+        sections.append(_render_resolved_config(cfg))
+    sections.append(_render_dependency_versions())
+    sections.append(render_artifacts(output_dir))
+    content = header + "\n\n".join(s.rstrip() for s in sections) + "\n"
+
+    # Per-invocation archive (#90) — second-resolution timestamp; full
+    # pipeline runs take minutes, so collisions don't occur in practice.
+    runs_dir = output_dir / "runs" / now.strftime("%Y%m%dT%H%M%S")
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    (runs_dir / "run.log").write_text(content, encoding="utf-8")
+
+    # Top-level "latest" copy (#57 back-compat).
     log_path = output_dir / "run.log"
-    log_path.write_text(header + body, encoding="utf-8")
+    log_path.write_text(content, encoding="utf-8")
     return log_path
+
+
+def _render_run_summary(rollup: dict) -> str:
+    """Aggregate stage success/failure counts across all stages (#90)."""
+    stages = rollup.get("stages", {}) or {}
+    total_ok = sum(r.get("ok", 0) for r in stages.values())
+    total_fail = sum(r.get("fail", 0) for r in stages.values())
+    return "\n".join([
+        "Run summary:",
+        f"  documents:          {rollup.get('total_documents', 0)}",
+        f"  stage runs ok:      {total_ok}",
+        f"  stage runs failed:  {total_fail}",
+    ])
+
+
+def _render_resolved_config(cfg: CorpuscleConfig) -> str:
+    """Serialize the validated, resolved config (#90). ``mode='json'``
+    coerces Path / enum fields to strings so the dump is plain YAML."""
+    try:
+        dumped = yaml.safe_dump(
+            cfg.model_dump(mode="json"), sort_keys=False, default_flow_style=False,
+        )
+    except Exception as e:  # never let a serialization quirk fail the run
+        dumped = f"(could not serialize config: {e})"
+    return "Resolved config:\n" + textwrap.indent(dumped.rstrip(), "  ")
+
+
+def _render_dependency_versions() -> str:
+    """Versions of the stack that produced this output (#90). Centered
+    on the ML pins (#98) whose silent drift broke a v0.5 build, plus the
+    serving deps, so a run.log pins exactly what to reproduce against."""
+    from importlib.metadata import PackageNotFoundError, version
+
+    pkgs = [
+        "docling", "torch", "transformers", "sentence-transformers",
+        "lancedb", "pyarrow", "mcp", "anthropic", "pydantic",
+    ]
+    lines = ["Dependency versions:", f"  {'python':<22s} {sys.version.split()[0]}"]
+    for p in pkgs:
+        try:
+            v = version(p)
+        except PackageNotFoundError:
+            v = "(not installed)"
+        lines.append(f"  {p:<22s} {v}")
+    return "\n".join(lines)
 
 
 def _distill_bundle(output_dir: Path) -> int:

--- a/tests/test_run_log.py
+++ b/tests/test_run_log.py
@@ -1,15 +1,14 @@
-"""Tests for the end-of-run `run.log` writer in `corpus run` (#57).
+"""Tests for the end-of-run `run.log` writer in `corpus run` (#57, #90).
 
 The helper lives at ``pipeline.cli._write_run_log``. It captures the
 same content as ``corpus status --report`` (rollup + cross-paper
 artifact presence) and writes it to ``<output_dir>/run.log`` so the
 operator has a self-contained record without re-running status.
 
-These tests pin two contracts:
-- Empty ``output_dir`` (no ``documents/`` yet) → no log written,
-  returns ``None``. Caller falls back to the legacy success message.
-- Populated ``output_dir`` → log file present with a header (version
-  + timestamp + path) and a non-empty body.
+#90 extends it into a central per-invocation log: a timestamped archive
+copy under ``<output_dir>/runs/<ts>/run.log`` (the top-level copy is
+kept as "latest" for #57 back-compat), plus argv, the resolved config,
+dependency-stack versions, and aggregate stage success/failure counts.
 """
 from __future__ import annotations
 
@@ -19,6 +18,7 @@ from pathlib import Path
 import pytest
 
 from pipeline.cli import _write_run_log
+from pipeline.config_schema import validate_config
 from pipeline.version import __version__
 
 
@@ -75,13 +75,59 @@ def test_writes_run_log_with_header_and_body(populated_output_dir: Path):
     assert "scan_detection" in content
 
 
-def test_overwrites_prior_log(populated_output_dir: Path):
-    """Each `corpus run` replaces the prior log with the current
-    snapshot — users wanting history are expected to git the file
-    or copy it aside. Verify the file is rewritten, not appended."""
+def test_overwrites_prior_top_level_log(populated_output_dir: Path):
+    """Each `corpus run` replaces the top-level "latest" copy with the
+    current snapshot (the per-invocation archive under runs/ keeps the
+    history). Verify the top-level file is rewritten, not appended."""
     log_path = populated_output_dir / "run.log"
     log_path.write_text("stale content from a prior run\n", encoding="utf-8")
     _write_run_log(populated_output_dir)
     content = log_path.read_text(encoding="utf-8")
     assert "stale content" not in content
     assert content.startswith("# corpus run report\n")
+
+
+# ---------------------------------------------------------------------------
+# #90 — central per-invocation log
+# ---------------------------------------------------------------------------
+
+
+def test_writes_timestamped_archive_copy(populated_output_dir: Path):
+    """The per-invocation archive lands under runs/<ts>/run.log with
+    content identical to the top-level "latest" copy."""
+    top = _write_run_log(populated_output_dir)
+    runs_dir = populated_output_dir / "runs"
+    assert runs_dir.is_dir()
+    archives = list(runs_dir.glob("*/run.log"))
+    assert len(archives) == 1
+    # The single timestamped dir name is a compact ISO stamp.
+    assert archives[0].parent.name.isdigit() is False  # contains a 'T'
+    assert "T" in archives[0].parent.name
+    assert archives[0].read_text(encoding="utf-8") == top.read_text(encoding="utf-8")
+
+
+def test_log_includes_argv_config_and_dep_versions(populated_output_dir: Path):
+    cfg = validate_config({"output_dir": str(populated_output_dir)})
+    argv = ["corpus", "run", "--config", "demo/config.yaml"]
+    log_path = _write_run_log(populated_output_dir, cfg=cfg, argv=argv)
+    content = log_path.read_text(encoding="utf-8")
+
+    # argv echoed in the header
+    assert "# argv corpus run --config demo/config.yaml" in content
+    # resolved config block (a known default key)
+    assert "Resolved config:" in content
+    assert "output_dir:" in content
+    # dependency versions — python is always present
+    assert "Dependency versions:" in content
+    assert "python" in content
+    # aggregate stage counts
+    assert "Run summary:" in content
+    assert "stage runs ok:" in content
+
+
+def test_run_summary_counts_match_rollup(populated_output_dir: Path):
+    """The one clean scan_detection stage in the fixture → 1 ok, 0 fail."""
+    log_path = _write_run_log(populated_output_dir)
+    content = log_path.read_text(encoding="utf-8")
+    assert "stage runs ok:      1" in content
+    assert "stage runs failed:  0" in content


### PR DESCRIPTION
Group-C ops item from `dev_docs/PLAN.md`. Extends the end-of-run `_write_run_log` (#57) into a self-contained, reproducible per-invocation record.

## What changed (`pipeline/cli.py`)
On top of the existing `corpus status --report` rollup, the run log now captures:
- **argv** — the exact invocation (header line).
- **Resolved config** — the validated pydantic config `model_dump(mode="json")` → YAML, so the log pins what actually ran (defaults filled in, paths resolved), not just what the user typed.
- **Dependency versions** — Python + the ML pins whose silent drift broke a v0.5 build (#98: docling, torch, transformers, sentence-transformers) plus the serving deps (lancedb, pyarrow, mcp, anthropic, pydantic). A run.log now says exactly what stack to reproduce against.
- **Run summary** — aggregate stage `ok` / `fail` counts across the rollup.

### Two copies
- `<output_dir>/runs/<timestamp>/run.log` — the **per-invocation archive**, so a sequence of runs leaves an auditable trail instead of overwriting.
- `<output_dir>/run.log` — unchanged **"latest"** copy at the top level for **#57 back-compat** (`corpus status`, the served bundle, existing tooling read it there).

The git SHA moved to its own `# git <sha>` header line so the existing `# corpus version <__version__>` line is preserved verbatim. The new `runs/` dir is invisible to `render_artifacts` (4 fixed paths) and to the served-bundle whitelist (include-only) — nothing downstream changes.

## Tests
Extends `tests/test_run_log.py`: timestamped-archive copy is content-identical to the top-level latest; argv / resolved-config / dependency-version sections present; run-summary counts match the rollup (1 ok / 0 fail on the clean fixture). Full local suite: **561 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)