### PR TITLE
#95: make build_taxon_mentions freshness fingerprint-aware

### DIFF
--- a/pipeline/taxon_mentions.py
+++ b/pipeline/taxon_mentions.py
@@ -70,12 +70,19 @@ def create_schema(conn: sqlite3.Connection) -> None:
         -- ``source_mtime`` is the mtime of taxa.json at the time we
         -- ingested it; on subsequent passes we re-ingest if the file
         -- on disk is newer (auto-reconcile after per-paper re-runs).
+        -- ``taxonomy_sha`` is the sha256 of the taxonomy.sqlite that
+        -- the ingested taxa.json was resolved against, read from the
+        -- paper's taxa-stage fingerprint (#95). mtime is unreliable
+        -- across HPC array-task nodes with skewed clocks, so a change
+        -- of recorded backbone forces a re-ingest even when mtime looks
+        -- fresh.
         CREATE TABLE IF NOT EXISTS papers_processed (
             corpus_hash    TEXT PRIMARY KEY,
             n_mentions     INTEGER NOT NULL,
             n_unique_taxa  INTEGER NOT NULL,
             processed_at   REAL NOT NULL,
-            source_mtime   REAL
+            source_mtime   REAL,
+            taxonomy_sha   TEXT
         );
 
         CREATE TABLE IF NOT EXISTS build_meta (
@@ -100,6 +107,12 @@ def create_schema(conn: sqlite3.Connection) -> None:
     have_cols = {row[1] for row in conn.execute("PRAGMA table_info(papers_processed)")}
     if "source_mtime" not in have_cols:
         conn.execute("ALTER TABLE papers_processed ADD COLUMN source_mtime REAL")
+    # #95 — same back-compat ALTER for the taxonomy fingerprint column.
+    # Older DBs read NULL taxonomy_sha, which the staleness check treats
+    # as "ingested against an unknown backbone" so the first fingerprint-
+    # aware pass re-ingests them once.
+    if "taxonomy_sha" not in have_cols:
+        conn.execute("ALTER TABLE papers_processed ADD COLUMN taxonomy_sha TEXT")
     conn.commit()
 
 
@@ -112,6 +125,29 @@ def parse_chunk_index(chunk_id: str) -> int:
     """Extract integer index from chunk_id like 'chunk_5' → 5."""
     m = _CHUNK_INDEX_RE.search(chunk_id or "")
     return int(m.group(1)) if m else -1
+
+
+def _paper_taxonomy_sha(hash_dir: Path) -> Optional[str]:
+    """Return the sha256 of the taxonomy.sqlite that this paper's
+    taxa.json was resolved against (#95), read from the taxa-stage
+    ``input_fingerprint`` in ``pipeline_state.json``.
+
+    Returns ``None`` when the file is missing/malformed, the taxa stage
+    has no recorded fingerprint, or the corpus has no taxonomy — all of
+    which mean "no recorded backbone to compare", and the staleness
+    check falls back to mtime alone.
+    """
+    state_path = hash_dir / "pipeline_state.json"
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(state, dict):
+        return None
+    rec = (state.get("stages") or {}).get("taxa_and_lexicon_extraction") or {}
+    taxonomy_fp = (rec.get("input_fingerprint") or {}).get("taxonomy") or {}
+    sha = taxonomy_fp.get("sha256")
+    return sha if isinstance(sha, str) else None
 
 
 # ── Main build logic ────────────────────────────────────────────────
@@ -166,7 +202,21 @@ def build(conn: sqlite3.Connection, output_dir: Path) -> dict:
     skipped = 0
     refreshed = 0
     errors = 0
+    lagging = 0
     batch = 0
+
+    # #95 — hash the current taxonomy.sqlite once so we can flag papers
+    # whose taxa.json was built against an older backbone (an operator
+    # hint to re-run `corpus run`, which regenerates taxa.json before a
+    # mention rebuild). None when the corpus has no taxonomy.
+    from .stages import _file_sha256
+    taxonomy_path = output_dir / "taxonomy.sqlite"
+    current_taxonomy_sha: Optional[str] = None
+    if taxonomy_path.exists():
+        try:
+            current_taxonomy_sha = _file_sha256(taxonomy_path)
+        except OSError as e:
+            logger.warning("Could not hash %s: %s", taxonomy_path, e)
 
     for hash_dir in sorted(docs_dir.iterdir()):
         if not hash_dir.is_dir():
@@ -188,15 +238,35 @@ def build(conn: sqlite3.Connection, output_dir: Path) -> dict:
             logger.warning("Skipping %s: %s", taxa_path, e)
             errors += 1
             continue
+        # #95 — the backbone a paper's taxa.json was resolved against,
+        # recorded in its taxa-stage fingerprint. Drives re-ingest
+        # independently of mtime.
+        paper_taxo_sha = _paper_taxonomy_sha(hash_dir)
+        if (
+            current_taxonomy_sha is not None
+            and paper_taxo_sha is not None
+            and paper_taxo_sha != current_taxonomy_sha
+        ):
+            lagging += 1
+
         cur = conn.execute(
-            "SELECT source_mtime FROM papers_processed WHERE corpus_hash = ?",
+            "SELECT source_mtime, taxonomy_sha FROM papers_processed "
+            "WHERE corpus_hash = ?",
             (corpus_hash,),
         )
         row = cur.fetchone()
         is_refresh = False
         if row is not None:
-            stored_mtime = row[0]
-            if stored_mtime is not None and stored_mtime >= current_mtime:
+            stored_mtime, stored_taxo_sha = row
+            mtime_fresh = stored_mtime is not None and stored_mtime >= current_mtime
+            # Skip only when BOTH signals say "unchanged": taxa.json is
+            # no newer than our last ingest AND the recorded backbone is
+            # the same one we ingested against. A changed backbone forces
+            # a re-ingest even when mtime looks fresh (#95 — the
+            # cross-component case mtime alone misses on HPC nodes with
+            # skewed clocks).
+            taxo_unchanged = paper_taxo_sha == stored_taxo_sha
+            if mtime_fresh and taxo_unchanged:
                 skipped += 1
                 continue
             is_refresh = True
@@ -221,9 +291,10 @@ def build(conn: sqlite3.Connection, output_dir: Path) -> dict:
         conn.execute(
             """INSERT OR REPLACE INTO papers_processed
                (corpus_hash, n_mentions, n_unique_taxa, processed_at,
-                source_mtime)
-               VALUES (?, ?, ?, ?, ?)""",
-            (corpus_hash, n_mentions, n_unique, time.time(), current_mtime),
+                source_mtime, taxonomy_sha)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (corpus_hash, n_mentions, n_unique, time.time(), current_mtime,
+             paper_taxo_sha),
         )
 
         total_papers += 1
@@ -244,12 +315,21 @@ def build(conn: sqlite3.Connection, output_dir: Path) -> dict:
         "Build complete: %d papers, %d mentions, %d skipped, %d refreshed, %d errors",
         total_papers, total_mentions, skipped, refreshed, errors,
     )
+    if lagging:
+        logger.warning(
+            "%d paper(s) have taxa.json resolved against an OLDER taxonomy "
+            "than the current %s. Their mentions reflect the stale backbone; "
+            "re-run `corpus run` to regenerate taxa.json before rebuilding "
+            "mentions.",
+            lagging, taxonomy_path.name,
+        )
     return {
         "papers": total_papers,
         "mentions": total_mentions,
         "skipped": skipped,
         "refreshed": refreshed,
         "errors": errors,
+        "lagging": lagging,
     }
 
 

--- a/tests/test_taxon_mentions_fast_path.py
+++ b/tests/test_taxon_mentions_fast_path.py
@@ -13,12 +13,15 @@ that the row dict returned to the tool path can be indexed by
 """
 from __future__ import annotations
 
+import json
+import os
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from pipeline.taxon_mentions import create_schema
+from pipeline.stages import _file_sha256
+from pipeline.taxon_mentions import build, create_schema
 from mcpsrv.indexes import TaxonMentionDB
 
 
@@ -67,3 +70,131 @@ def test_mentions_for_taxon_filters_by_corpus_hash(tmp_path):
 
     assert db.mentions_for_taxon("1371", corpus_hash="abc123def456")
     assert not db.mentions_for_taxon("1371", corpus_hash="missinghash")
+
+
+# ---------------------------------------------------------------------------
+# #95 — fingerprint-aware freshness
+# ---------------------------------------------------------------------------
+#
+# The mtime gate alone misses the cross-component case: a taxonomy
+# refresh + per-paper re-run regenerates taxa.json against a new
+# backbone, but on an HPC filesystem the regenerated file's mtime can
+# be <= the mtime we last recorded (clock skew across array-task
+# nodes), so an mtime-only gate skips it forever. The fix gates on the
+# taxonomy sha256 recorded in each paper's taxa-stage fingerprint.
+
+
+_HASH = "abc123def456"
+
+
+def _write_paper(output_dir: Path, taxa_mtime: float, taxonomy_sha: str | None) -> Path:
+    """Write one paper's taxa.json + pipeline_state.json under
+    documents/<hash>/, stamping the taxa stage with ``taxonomy_sha`` and
+    forcing taxa.json's mtime to ``taxa_mtime``."""
+    hash_dir = output_dir / "documents" / _HASH
+    hash_dir.mkdir(parents=True, exist_ok=True)
+
+    taxa_path = hash_dir / "taxa.json"
+    taxa_path.write_text(json.dumps({
+        "unique_taxa": 1,
+        "mentions": [{
+            "chunk_id": "chunk_0", "text_span": [10, 17],
+            "accepted_taxon_id": "1371", "matched_text": "Nanomia",
+            "accepted_name": "Nanomia", "rank": "Genus", "name_type": "binomial",
+        }],
+    }), encoding="utf-8")
+    os.utime(taxa_path, (taxa_mtime, taxa_mtime))
+
+    state = {"stages": {"taxa_and_lexicon_extraction": {
+        "input_fingerprint": (
+            {"taxonomy": {"sha256": taxonomy_sha}} if taxonomy_sha else {}
+        ),
+    }}}
+    (hash_dir / "pipeline_state.json").write_text(json.dumps(state), encoding="utf-8")
+    return taxa_path
+
+
+def _write_taxonomy(output_dir: Path, content: bytes) -> str:
+    """Write a stand-in taxonomy.sqlite (build only hashes it) and
+    return its sha256."""
+    p = output_dir / "taxonomy.sqlite"
+    p.write_bytes(content)
+    return _file_sha256(p)
+
+
+def _build(output_dir: Path) -> dict:
+    conn = sqlite3.connect(output_dir / "taxon_mentions.sqlite")
+    create_schema(conn)
+    stats = build(conn, output_dir)
+    conn.close()
+    return stats
+
+
+def test_taxonomy_rebuild_reingests_despite_stale_mtime(tmp_path):
+    """The exact #95 repro: rebuild taxonomy.sqlite, re-run the per-paper
+    taxa stage (new recorded backbone), but with taxa.json's mtime NOT
+    advanced. An mtime-only gate would skip; the fingerprint gate must
+    re-ingest."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    sha_v1 = _write_taxonomy(output_dir, b"taxonomy version one")
+    _write_paper(output_dir, taxa_mtime=1000.0, taxonomy_sha=sha_v1)
+    stats = _build(output_dir)
+    assert stats["papers"] == 1 and stats["mentions"] == 1
+
+    # Rebuild the taxonomy and re-run the taxa stage against it, but
+    # leave taxa.json's mtime at (in fact below) the recorded value.
+    sha_v2 = _write_taxonomy(output_dir, b"taxonomy version TWO (different)")
+    assert sha_v2 != sha_v1
+    _write_paper(output_dir, taxa_mtime=999.0, taxonomy_sha=sha_v2)
+
+    stats2 = _build(output_dir)
+    assert stats2["refreshed"] == 1, "changed backbone must force a re-ingest"
+    assert stats2["skipped"] == 0
+    assert stats2["mentions"] == 1  # re-ingested, not duplicated
+
+    # And the mention rows are present exactly once.
+    conn = sqlite3.connect(output_dir / "taxon_mentions.sqlite")
+    (n,) = conn.execute("SELECT COUNT(*) FROM taxon_mentions").fetchone()
+    (stored_sha,) = conn.execute(
+        "SELECT taxonomy_sha FROM papers_processed WHERE corpus_hash = ?",
+        (_HASH,),
+    ).fetchone()
+    conn.close()
+    assert n == 1
+    assert stored_sha == sha_v2
+
+
+def test_unchanged_backbone_skips_on_rerun(tmp_path):
+    """Idempotency: same backbone + same mtime → the second build skips,
+    no pointless re-ingest."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    sha = _write_taxonomy(output_dir, b"stable taxonomy")
+    _write_paper(output_dir, taxa_mtime=1000.0, taxonomy_sha=sha)
+
+    assert _build(output_dir)["papers"] == 1
+    stats2 = _build(output_dir)
+    assert stats2["skipped"] == 1
+    assert stats2["refreshed"] == 0 and stats2["papers"] == 0
+
+
+def test_lagging_backbone_flagged_without_spurious_reingest(tmp_path):
+    """taxonomy.sqlite advanced but the per-paper taxa stage hasn't
+    re-run (taxa.json still records the old backbone): the paper is
+    flagged as lagging, and re-ingesting the still-stale taxa.json is
+    NOT triggered (its recorded backbone is unchanged since our ingest)."""
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    sha_v1 = _write_taxonomy(output_dir, b"taxonomy v1")
+    _write_paper(output_dir, taxa_mtime=1000.0, taxonomy_sha=sha_v1)
+    _build(output_dir)
+
+    # Operator rebuilt taxonomy.sqlite but did NOT re-run `corpus run`,
+    # so taxa.json + its fingerprint still point at v1.
+    _write_taxonomy(output_dir, b"taxonomy v2 not yet propagated")
+    stats2 = _build(output_dir)
+    assert stats2["lagging"] == 1
+    assert stats2["skipped"] == 1  # recorded backbone unchanged → no re-ingest
+    assert stats2["refreshed"] == 0


### PR DESCRIPTION
Group-B correctness bug from `dev_docs/PLAN.md`.

## The bug
`build_taxon_mentions` skips papers already in `papers_processed` using a taxa.json **mtime** gate. That gate is correct in isolation, but misses a cross-component case: a taxonomy refresh + per-paper re-run regenerates `taxa.json` against a new backbone, yet on an HPC filesystem the regenerated file's mtime can be **≤** the value we last recorded (clock skew across array-task nodes). An mtime-only gate then skips the paper forever and the mention DB keeps serving the **stale backbone**.

## The fix — gate on the recorded taxonomy fingerprint
The taxa stage already stamps the taxonomy `sha256` it resolved against into each paper's `pipeline_state.json` (`input_fingerprint.taxonomy.sha256`). Use that, not mtime alone:

- `papers_processed` gains a `taxonomy_sha` column (back-compat `ALTER`; old rows read `NULL` → re-ingested once).
- `_paper_taxonomy_sha()` reads the taxa-stage fingerprint.
- A paper is **skipped only when BOTH** mtime is no-newer **AND** the recorded backbone equals what we ingested against. A changed backbone forces a re-ingest regardless of mtime.
- `build()` hashes the current `taxonomy.sqlite` once and **flags papers lagging** the on-disk backbone (a `lagging` count + warning) — an operator hint to re-run `corpus run` first — *without* spuriously re-ingesting still-stale `taxa.json` (its recorded backbone hasn't changed since our ingest, so idempotency holds).

## Tests (`tests/test_taxon_mentions_fast_path.py`, per the plan's pointer)
- **The exact repro:** rebuild `taxonomy.sqlite` → re-run the taxa stage with a *non-advanced* mtime → asserts re-ingest (`refreshed == 1`, mentions not duplicated, stored sha updated).
- Idempotent skip on unchanged backbone.
- Lagging backbone flagged without spurious re-ingest.

Full local suite: **564 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)