### PR TITLE
#92: corpus debug-pdf single-PDF debug runner

### DIFF
--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -502,6 +502,111 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return EXIT_OK
 
 
+def _cmd_debug_pdf(args: argparse.Namespace) -> int:
+    """Run the per-paper pipeline on a single PDF with verbose stage
+    tracing and no bundle / cross-paper steps (#92).
+
+    A focused troubleshooting runner for hard documents. It drives
+    exactly the per-PDF stages ``run_pdf_processing_pipeline`` runs
+    (huge-doc gate, scan detection, PDF prep, docling extraction,
+    chunking, figures — plus the bibliography stage when ``--grobid-url``
+    is given), writes the intermediate artifacts under a debug directory
+    you can inspect, and prints a per-stage ok/fail + timing table so a
+    failure is immediately attributable to a stage. It deliberately runs
+    inline (no fork) and with ``resume=False`` so every stage executes
+    every time. The taxa/lexicon stages — which need corpus-level
+    ``taxonomy.sqlite`` / lexicon inputs — are out of scope; use a full
+    `corpus run` for those.
+    """
+    import tempfile
+
+    from .grobid_client import GrobidClient
+    from .io import calculate_pdf_hash, create_summary_json, short_hash
+    from .log import per_pdf_file_log, setup_root_logging
+    from .runner import run_pdf_processing_pipeline
+
+    pdf_path: Path = args.pdf
+    if not pdf_path.is_file():
+        print_status(f"not a PDF file: {pdf_path}", status="fail")
+        return EXIT_CONFIG_ERROR
+
+    # This is a debug command — default to verbose so the stage trace is
+    # visible without requiring -v. -q/-vv still take precedence.
+    setup_root_logging(logging.DEBUG if args.verbose >= 2 else logging.INFO)
+    log = logging.getLogger("pipeline.debug_pdf")
+
+    debug_root = (args.output_dir or (Path.cwd() / "debug-pdf")).resolve()
+    pdf_hash_full = calculate_pdf_hash(pdf_path)
+    hash_dir = debug_root / short_hash(pdf_hash_full)
+    hash_dir.mkdir(parents=True, exist_ok=True)
+    print_status(
+        f"debug-pdf: {pdf_path.name} ({short_hash(pdf_hash_full)}) → {hash_dir}",
+        status="info",
+    )
+
+    grobid_client: Optional[GrobidClient] = None
+    if args.grobid_url:
+        grobid_client = GrobidClient(base_url=args.grobid_url)
+        print_status(f"bibliography stage enabled via Grobid at {args.grobid_url}",
+                     status="info")
+    else:
+        print_status(
+            "bibliography stage skipped (pass --grobid-url to enable); "
+            "taxa/lexicon stages are out of scope for debug-pdf",
+            status="info",
+        )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with per_pdf_file_log(hash_dir) as log_path:
+            log.info("pipeline.log: %s", log_path)
+            log.info("pdf_hash_full: %s", pdf_hash_full)
+            summary = run_pdf_processing_pipeline(
+                pdf_path, hash_dir, Path(temp_dir),
+                grobid_client=grobid_client,
+                taxonomy_db=None,
+                lexicons=None,
+                bib_index=None,
+                resume=False,
+            )
+        create_summary_json(
+            pdf_hash_full, [pdf_path], pdf_path.parent, hash_dir, summary,
+        )
+
+    _print_debug_pdf_trace(summary, hash_dir)
+    return EXIT_OK if summary.get("status") == "success" else EXIT_GENERIC
+
+
+def _print_debug_pdf_trace(summary: dict, hash_dir: Path) -> None:
+    """Print a per-stage ok/fail + timing table for `corpus debug-pdf`."""
+    timings = summary.get("stage_timings") or []
+    failures = {f.get("stage"): f for f in (summary.get("stage_failures") or [])}
+    skipped = set(summary.get("skipped_stages") or [])
+
+    print()
+    print(f"Stage trace ({len(timings)} stages run):")
+    for t in timings:
+        stage = t.get("stage", "?")
+        ok = t.get("ok")
+        dur = t.get("duration_s")
+        mark = "✓" if ok else "✗"
+        dur_s = f"{dur:6.2f}s" if isinstance(dur, (int, float)) else "     ?"
+        line = f"  {mark} {stage:<28s} {dur_s}"
+        if not ok and stage in failures:
+            line += f"   {failures[stage].get('error', '')}"
+        print(line)
+    if skipped:
+        print(f"  (skipped, artifact already present: {', '.join(sorted(skipped))})")
+
+    status = summary.get("status", "unknown")
+    n_files = len(summary.get("files_created") or [])
+    print()
+    print_status(
+        f"status={status}; {n_files} artifact(s) written under {hash_dir}",
+        status="ok" if status == "success" else "fail",
+    )
+    print(f"Full log: {hash_dir / 'pipeline.log'}")
+
+
 def _write_run_log(
     output_dir: Path,
     cfg: Optional[CorpuscleConfig] = None,
@@ -939,7 +1044,7 @@ _corpus_complete() {
     prev="${COMP_WORDS[COMP_CWORD-1]}"
 
     # Top-level verbs.
-    local verbs="init run status serve bib check completion"
+    local verbs="init run debug-pdf status serve bib check completion"
     if [[ ${COMP_CWORD} -eq 1 ]] || [[ "$prev" == "-c" || "$prev" == "--config" ]]; then
         if [[ "$prev" == "-c" || "$prev" == "--config" ]]; then
             COMPREPLY=( $(compgen -f -- "$cur") )
@@ -953,6 +1058,7 @@ _corpus_complete() {
     cmd="${COMP_WORDS[1]}"
     case "$cmd" in
         run)        COMPREPLY=( $(compgen -W "--dry-run --force-rebuild --no-vision --no-bundle --enrich-bhl -h --help" -- "$cur") ) ;;
+        debug-pdf)  COMPREPLY=( $(compgen -W "--output-dir --grobid-url -h --help" -- "$cur") ) ;;
         status)     COMPREPLY=( $(compgen -W "--output-dir --report --json --list-hashes --filter-stage --filter-reason --filter-gate -v -h --help" -- "$cur") ) ;;
         serve)      COMPREPLY=( $(compgen -W "--output-dir --transport --host --port --auth-token-file -h --help" -- "$cur") ) ;;
         bib)        COMPREPLY=( $(compgen -W "export import -h --help" -- "$cur") ) ;;
@@ -973,6 +1079,7 @@ _corpus() {
     verbs=(
         'init:scaffold config.yaml in cwd'
         'run:full pipeline + post-pipeline + bundle'
+        'debug-pdf:run the per-paper pipeline on one PDF with stage tracing'
         'status:build-state rollup + report'
         'serve:MCP server'
         'bib:BibTeX round-trip'
@@ -984,6 +1091,7 @@ _corpus() {
     elif (( CURRENT >= 3 )); then
         case "$words[2]" in
             run)        _arguments '--dry-run' '--force-rebuild' '--no-vision' '--no-bundle' '--enrich-bhl' ;;
+            debug-pdf)  _arguments '--output-dir:DIR:_files -/' '--grobid-url:URL:' '1:PDF:_files' ;;
             status)     _arguments '--output-dir:DIR:_files -/' '--report' '--json' '--list-hashes' ;;
             serve)      _arguments '--output-dir:DIR:_files -/' '--transport' '--host' '--port' '--auth-token-file:FILE:_files' ;;
             bib)        _values 'subcommand' export import ;;
@@ -998,6 +1106,7 @@ _FISH_COMPLETION = """\
 # corpus(1) fish completion — generated by `corpus completion fish`
 complete -c corpus -n "__fish_use_subcommand" -a init        -d 'scaffold config.yaml in cwd'
 complete -c corpus -n "__fish_use_subcommand" -a run         -d 'full pipeline + post-pipeline + bundle'
+complete -c corpus -n "__fish_use_subcommand" -a debug-pdf   -d 'run the per-paper pipeline on one PDF with stage tracing'
 complete -c corpus -n "__fish_use_subcommand" -a status      -d 'build-state rollup + report'
 complete -c corpus -n "__fish_use_subcommand" -a serve       -d 'MCP server'
 complete -c corpus -n "__fish_use_subcommand" -a bib         -d 'BibTeX round-trip'
@@ -1009,6 +1118,7 @@ complete -c corpus -l cite -d 'Print the citation (plain | bibtex)'
 complete -c corpus -s v -d 'verbose (-vv = debug all)'
 complete -c corpus -s q -l quiet
 complete -c corpus -n "__fish_seen_subcommand_from run" -l dry-run -l force-rebuild -l no-vision -l no-bundle -l enrich-bhl
+complete -c corpus -n "__fish_seen_subcommand_from debug-pdf" -l output-dir -l grobid-url
 complete -c corpus -n "__fish_seen_subcommand_from completion" -a 'bash zsh fish'
 """
 
@@ -1277,6 +1387,40 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Enrich pre-DOI references against the Biodiversity "
                        "Heritage Library (slow, rate-limited; #64)")
     run_p.set_defaults(func=_cmd_run)
+
+    # --- debug-pdf ---
+    debug_pdf_p = sub.add_parser(
+        "debug-pdf",
+        help="Run the per-paper pipeline on a single PDF with stage tracing.",
+        description=(
+            "Troubleshooting runner for hard documents (#92). Drives one "
+            "PDF through the per-paper extraction pipeline "
+            "(huge-doc gate → scan detection → PDF prep → docling "
+            "extraction → chunking → figures, plus bibliography when "
+            "--grobid-url is given), writes the intermediate artifacts "
+            "under a debug directory for inspection, and prints a "
+            "per-stage ok/fail + timing table so a failure is immediately "
+            "attributable to a stage. Runs inline with resume disabled — "
+            "every stage executes every time. No bundle, no cross-paper "
+            "steps. The taxa/lexicon stages need corpus-level inputs and "
+            "are out of scope; use a full `corpus run` for those."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    debug_pdf_p.add_argument(
+        "pdf", type=Path, help="Path to the single PDF to debug.",
+    )
+    debug_pdf_p.add_argument(
+        "--output-dir", type=Path, default=None,
+        help="Where to write the debug artifacts (default: ./debug-pdf/). "
+             "A <hash>/ subdir is created per PDF, mirroring documents/.",
+    )
+    debug_pdf_p.add_argument(
+        "--grobid-url", default=None, metavar="URL",
+        help="Enable the bibliography stage against a Grobid server "
+             "(e.g. http://localhost:8070). Skipped when omitted.",
+    )
+    debug_pdf_p.set_defaults(func=_cmd_debug_pdf)
 
     # --- status ---
     status_p = sub.add_parser(

--- a/tests/test_debug_pdf.py
+++ b/tests/test_debug_pdf.py
@@ -1,0 +1,129 @@
+"""Tests for `corpus debug-pdf` — the single-PDF debug runner (#92).
+
+The command drives one PDF through ``run_pdf_processing_pipeline`` with
+stage tracing and no bundle. The actual extraction pipeline needs
+docling + models, so these tests stub ``run_pdf_processing_pipeline``
+and pin the command's *wiring*: hash-dir layout, summary.json write,
+exit code reflecting stage status, and the not-a-file guard.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+import pipeline.cli as cli
+from pipeline.io import calculate_pdf_hash, short_hash
+
+
+def _args(pdf: Path, output_dir: Path, grobid_url=None, verbose=0):
+    return argparse.Namespace(
+        pdf=pdf, output_dir=output_dir, grobid_url=grobid_url, verbose=verbose,
+    )
+
+
+@pytest.fixture
+def fake_pdf(tmp_path: Path) -> Path:
+    # calculate_pdf_hash only reads bytes; content needn't be real PDF.
+    p = tmp_path / "hard_document.pdf"
+    p.write_bytes(b"%PDF-1.4 fake bytes for hashing\n")
+    return p
+
+
+def _stub_pipeline(summary: dict):
+    """Return a stub for run_pdf_processing_pipeline that records its
+    call and returns the given summary."""
+    calls = {}
+
+    def _stub(pdf_path, hash_dir, temp_dir, **kwargs):
+        calls["pdf_path"] = pdf_path
+        calls["hash_dir"] = hash_dir
+        calls["kwargs"] = kwargs
+        return summary
+
+    _stub.calls = calls
+    return _stub
+
+
+def test_debug_pdf_success(fake_pdf, tmp_path, monkeypatch, capsys):
+    out = tmp_path / "debug-out"
+    summary = {
+        "status": "success",
+        "stage_timings": [
+            {"stage": "scan_detection", "ok": True, "duration_s": 0.1},
+            {"stage": "docling_extraction", "ok": True, "duration_s": 2.5},
+        ],
+        "stage_failures": [],
+        "skipped_stages": [],
+        "files_created": ["text.json", "chunks.json"],
+    }
+    stub = _stub_pipeline(summary)
+    monkeypatch.setattr("pipeline.runner.run_pdf_processing_pipeline", stub)
+
+    rc = cli._cmd_debug_pdf(_args(fake_pdf, out))
+    assert rc == cli.EXIT_OK
+
+    # Hash-dir layout mirrors documents/<short-hash>/.
+    sh = short_hash(calculate_pdf_hash(fake_pdf))
+    hash_dir = out / sh
+    assert hash_dir.is_dir()
+    assert (hash_dir / "summary.json").is_file()
+    assert stub.calls["hash_dir"] == hash_dir
+    # No grobid by default → bibliography stage gets no client.
+    assert stub.calls["kwargs"]["grobid_client"] is None
+    assert stub.calls["kwargs"]["resume"] is False
+
+    captured = capsys.readouterr().out
+    assert "Stage trace" in captured
+    assert "scan_detection" in captured
+    assert "docling_extraction" in captured
+
+
+def test_debug_pdf_failure_exit_code(fake_pdf, tmp_path, monkeypatch):
+    summary = {
+        "status": "failed",
+        "stage_timings": [
+            {"stage": "docling_extraction", "ok": False, "duration_s": 1.0},
+        ],
+        "stage_failures": [
+            {"stage": "docling_extraction", "error": "docling crashed"},
+        ],
+        "skipped_stages": [],
+        "files_created": [],
+    }
+    monkeypatch.setattr(
+        "pipeline.runner.run_pdf_processing_pipeline", _stub_pipeline(summary),
+    )
+    rc = cli._cmd_debug_pdf(_args(fake_pdf, tmp_path / "out"))
+    assert rc == cli.EXIT_GENERIC
+
+
+def test_debug_pdf_grobid_url_wires_client(fake_pdf, tmp_path, monkeypatch):
+    summary = {"status": "success", "stage_timings": [], "stage_failures": [],
+               "skipped_stages": [], "files_created": []}
+    stub = _stub_pipeline(summary)
+    monkeypatch.setattr("pipeline.runner.run_pdf_processing_pipeline", stub)
+
+    sentinel = object()
+    monkeypatch.setattr(
+        "pipeline.grobid_client.GrobidClient", lambda base_url: sentinel,
+    )
+    cli._cmd_debug_pdf(_args(fake_pdf, tmp_path / "out",
+                             grobid_url="http://localhost:8070"))
+    assert stub.calls["kwargs"]["grobid_client"] is sentinel
+
+
+def test_debug_pdf_rejects_non_file(tmp_path):
+    missing = tmp_path / "nope.pdf"
+    rc = cli._cmd_debug_pdf(_args(missing, tmp_path / "out"))
+    assert rc == cli.EXIT_CONFIG_ERROR
+
+
+def test_debug_pdf_registered_in_parser():
+    """The subparser is wired into the router with the right handler."""
+    parser = cli._build_parser()
+    args = parser.parse_args(["debug-pdf", "some.pdf", "--grobid-url", "http://x"])
+    assert args.func is cli._cmd_debug_pdf
+    assert args.pdf == Path("some.pdf")
+    assert args.grobid_url == "http://x"


### PR DESCRIPTION
Group-C ops item from `dev_docs/PLAN.md`. A focused troubleshooting runner for hard documents.

## What it does
`corpus debug-pdf <pdf>` drives one PDF through `run_pdf_processing_pipeline`'s per-paper stages — huge-doc gate → scan detection → PDF prep → docling extraction → chunking → figures (plus the bibliography stage when `--grobid-url` is given) — and:
- writes the intermediate artifacts under `./debug-pdf/<short-hash>/` (mirroring `documents/<hash>/`) so you can inspect `text.json`, `figures.json`, `pipeline.log`, etc.;
- prints a **per-stage ok/fail + timing table** so a failure is immediately attributable to a stage;
- runs **inline** (no fork) with **`resume=False`** so every stage executes every time;
- does **no bundle / no cross-paper steps**.

```
Stage trace (2 stages run):
  ✓ scan_detection                 0.10s
  ✗ docling_extraction             1.00s   docling crashed
[fail] status=failed; 0 artifact(s) written under ./debug-pdf/<hash>
```

Verbose by default (the trace is the point); `-q`/`-vv` still take precedence. Exit code is `0` on `status=="success"`, else `1`.

The **taxa/lexicon** stages need corpus-level `taxonomy.sqlite` / lexicon inputs and are out of scope — a single-PDF debug rarely touches them; use a full `corpus run` for those.

## Wiring
New subparser in the `pipeline/cli.py` router next to `run`/`status`, with **bash + zsh + fish** completions updated (verb + per-verb flags).

## Tests
`tests/test_debug_pdf.py` stubs the heavy `run_pdf_processing_pipeline` and pins the wiring: hash-dir layout, `summary.json` write, no-grobid default vs `--grobid-url` client wiring, exit code reflecting stage status, the not-a-file guard, and parser registration. Full local suite: **569 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)