### PR TITLE
fix: scrub stale VisionConfig/cfg.vision refs left by #102

### DIFF
--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -866,16 +866,23 @@ def _cmd_check(args: argparse.Namespace) -> int:
     else:
         pstatus("GPU: none (CPU-only; embedding pass will be slow)", status="warn")
 
-    # 3. Vision backend usability — under #65 a missing capability is
-    # a warn (the pass auto-skips at run time with the same message),
-    # not a hard precondition failure.
-    vision_skip = _vision_skip_reason(cfg.vision.backend)
-    if cfg.vision.backend == "none":
-        pstatus("Vision pass: disabled in config", status="warn")
-    elif vision_skip is None:
-        pstatus(f"Vision pass: backend `{cfg.vision.backend}` ready", status="ok")
+    # 3. Figure panel-ROI detection (#102). Under #65 an unusable vision
+    # backend is a warn (the run downgrades to the OCR floor with the
+    # same message), not a hard precondition failure.
+    panel_mode = cfg.figures.panel_detection
+    if panel_mode == "off":
+        pstatus("Figure panels: disabled in config (panel_detection: off)",
+                status="warn")
+    elif panel_mode == "ocr":
+        pstatus("Figure panels: OCR floor (panel_detection: ocr; CPU-only)",
+                status="ok")
     else:
-        pstatus(f"Vision pass: would skip — {vision_skip}", status="warn")
+        vision_skip = _vision_skip_reason(panel_mode)
+        if vision_skip is None:
+            pstatus(f"Figure panels: `{panel_mode}` ready", status="ok")
+        else:
+            pstatus(f"Figure panels: would downgrade to OCR floor — {vision_skip}",
+                    status="warn")
 
     # 4. Grobid reachability
     if cfg.grobid.disable:

--- a/pipeline/config_schema.py
+++ b/pipeline/config_schema.py
@@ -277,6 +277,7 @@ __all__ = [
     "BibliographyConfig",
     "ChunkingConfig",
     "CorpuscleConfig",
+    "FiguresConfig",
     "GrobidConfig",
     "HugeDocumentConfig",
     "LicensingConfig",
@@ -285,6 +286,5 @@ __all__ = [
     "StageTimeoutsConfig",
     "TaxonomyConfig",
     "ValidationError",
-    "VisionConfig",
     "validate_config",
 ]


### PR DESCRIPTION
Two #102 leftovers that pass locally but fail CI (caught by CI on the #118/#119 merges):

1. **`config_schema.__all__` still exported `VisionConfig`** (renamed to `FiguresConfig`) — an undefined name that fails the **T0 pyflakes "no undefined names" gate**. That gate `pytest.skip`s locally when the `pyflakes` console-script isn't on PATH, so the local suite stayed green and it slipped through.
2. **`corpus check` still read `cfg.vision.backend`** → `AttributeError: 'CorpuscleConfig' object has no attribute 'vision'` in the **T1/T2 demo-build lane**. Rewired to `figures.panel_detection` (off / ocr / vision-* reporting).

Verified locally with the actual tools: `python -m pyflakes pipeline mcpsrv bib` → zero undefined names; `corpus check --config demo/config.yaml` reports `Figure panels: OCR floor` cleanly. Full suite 587 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)