### PR TITLE
#102 follow-up: expose --figure-panels on corpus run + fix stale figure docs

### DIFF
--- a/dev_docs/OVERVIEW.md
+++ b/dev_docs/OVERVIEW.md
@@ -92,7 +92,7 @@ A corpuscle can span centuries of literature — 19th-century engraved plates wi
 
 ### Lifecycle (per PDF)
 
-The eleven steps below are all driven per-PDF from `pipeline/runner.py`. The "Stage · when" column ties each step back to the stage vocabulary above: steps 1–7 and 11 run during Stage 1 (CPU) — every paper, except the conditional PyMuPDF fallback (step 5). Steps 8–10 are the optional figure **passes** enabled by flags; of those, only Pass 3b leaves the CPU stage (GPU/API).
+The eleven steps below are all driven per-PDF from `pipeline/runner.py`. The "Stage · when" column ties each step back to the stage vocabulary above: steps 1–7 and 11 run during Stage 1 (CPU) — every paper, except the conditional PyMuPDF fallback (step 5). Steps 8–10 are the figure **passes** selected by `figures.panel_detection` (Pass 3a `ocr` is the default floor; Pass 3b is opt-in via the `vision-*` modes; Pass 3c auto-follows a compound); of those, only Pass 3b leaves the CPU stage (GPU/API).
 
 | # | Step (figure pass) | Code | Stage · when | Writes |
 |---|---|---|---|---|
@@ -129,12 +129,14 @@ Captions are the highest-value annotation per figure and the hardest in historic
 
 When neither path finds text, the figure keeps `caption_source: null` — a useful signal for figure-quality triage.
 
-### Optional passes — what is lost when they are skipped
+### Selecting a pass — and what is lost when one is skipped
 
-All of steps 8–10 are **off by default**; a plain `corpus run` produces figures, captions, numbers, classification, dedup/panel-letters, `missing_figures`, and chunk links, but no pixel-level panel geometry and no compound splitting.
+Panel detection is selected by **`figures.panel_detection`** in the corpuscle's `config.yaml` (`ocr` / `vision-local` / `vision-claude` / `off`; #102), overridable per run with **`corpus run --figure-panels <mode>`**. The deprecated `corpus run --no-vision` is an alias for `--figure-panels ocr`. Under the hood `corpus run` translates this into the `--figure-panels` flag on `pipeline.main` / the orchestrator (which is where it appears in `slurm/` jobs).
 
-- **Without Pass 3a or 3b (no `rois`):** there is no geometric segmentation of multi-panel figures. `get_figure_image(label="B")` can only fall back to the whole figure; panel-level retrieval degrades to the caption-derived `panels_from_caption` descriptions (text, not crops).
-- **Pass 3a (OCR) vs Pass 3b (vision):** 3a (Tesseract on a 3×-upscaled crop) detects only printed letter labels and has low recall on line-art/engraved plates; 3b (Qwen2.5-VL locally or Claude Haiku via API) is substantially more reliable and is the **only** pass that detects *compound* figures — a single extracted image that actually contains several numbered figures (common in plate-heavy monographs). The two are mutually exclusive, selected by `--figure-panels` (`ocr` is the default CPU floor; `vision-local` / `vision-claude` run 3b instead; `off` runs neither).
+Since #102 the default is **`ocr`** — Pass 3a is the CPU floor and runs on a plain `corpus run`. So the default output now includes OCR `rois`; only `panel_detection: off` reproduces the pre-#102 "no panel geometry" behavior.
+
+- **With `off` (no Pass 3a or 3b → no `rois`):** there is no geometric segmentation of multi-panel figures. `get_figure_image(label="B")` can only fall back to the whole figure; panel-level retrieval degrades to the caption-derived `panels_from_caption` descriptions (text, not crops).
+- **Pass 3a (OCR, the `ocr` default) vs Pass 3b (vision):** 3a (Tesseract on a 3×-upscaled crop) detects only printed letter labels and has low recall on line-art/engraved plates; 3b (Qwen2.5-VL locally or Claude Haiku via API, the `vision-local` / `vision-claude` modes) is substantially more reliable and is the **only** pass that detects *compound* figures — a single extracted image that actually contains several numbered figures (common in plate-heavy monographs). The two are mutually exclusive.
 - **Without Pass 3b → no Pass 3c:** compound plates are never split. A `fig_3-4.png`-style image stays a single record with an ambiguous `figure_number`, its embedded sub-figures remain invisible to `figure_number`-keyed queries, and the `missing_figures[]` entries that 3c would have matched to recovered sub-figures (`image_shared_with` links, real numbers + captions) are left unresolved. The `missing_figures` list itself is still produced (Pass 2.5) as a coverage signal.
 
 Because these passes are GPU/API-cost-bearing, the corpus-scale validation of figure coverage is tracked separately ([#11](https://github.com/caseywdunn/corpus/issues/11)), and figure-number recovery on old/scanned papers is an open gap ([#16](https://github.com/caseywdunn/corpus/issues/16)). When a new layout exposes a new failure mode, capture it as a ground-truth fixture under `tests/` so the fix is guarded against regression.

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -348,19 +348,23 @@ def _build_orchestrator_argv(
     if cfg.grobid.url:
         sub_argv += ["--grobid-url", cfg.grobid.url]
 
-    # Figure panel-ROI detection (#102): figures.panel_detection selects
-    # the pass. `--no-vision` downgrades a vision backend to the OCR
-    # floor (not off — the OCR pass is the cheap default baseline).
-    # Capability detection (#65) likewise downgrades an unusable vision
-    # backend to OCR with a one-line nudge rather than hard-failing
-    # Pass 3b deep into the run.
-    panel_mode = cfg.figures.panel_detection
-    if args.no_vision and panel_mode in ("vision-local", "vision-claude"):
+    # Figure panel-ROI detection (#102). Effective mode precedence:
+    # explicit `--figure-panels` > `--no-vision` (deprecated alias for
+    # `ocr`) > the corpuscle's `figures.panel_detection` config key.
+    if args.figure_panels is not None:
+        panel_mode = args.figure_panels
+    elif args.no_vision:
         print_status(
-            "--no-vision: using the OCR panel floor instead of the vision pass",
+            "--no-vision is a deprecated alias for `--figure-panels ocr` "
+            "(CPU OCR-panel floor)",
             status="info",
         )
         panel_mode = "ocr"
+    else:
+        panel_mode = cfg.figures.panel_detection
+    # Capability detection (#65) downgrades an unusable vision backend to
+    # the OCR floor with a one-line nudge rather than hard-failing Pass 3b
+    # deep into the run.
     if panel_mode in ("vision-local", "vision-claude"):
         skip_reason = _vision_skip_reason(panel_mode)
         if skip_reason is not None:
@@ -1074,7 +1078,7 @@ _corpus_complete() {
     # Per-verb flag completions.
     cmd="${COMP_WORDS[1]}"
     case "$cmd" in
-        run)        COMPREPLY=( $(compgen -W "--dry-run --force-rebuild --no-vision --no-bundle --enrich-bhl -h --help" -- "$cur") ) ;;
+        run)        COMPREPLY=( $(compgen -W "--dry-run --force-rebuild --figure-panels --no-vision --no-bundle --enrich-bhl -h --help" -- "$cur") ) ;;
         debug-pdf)  COMPREPLY=( $(compgen -W "--output-dir --grobid-url -h --help" -- "$cur") ) ;;
         status)     COMPREPLY=( $(compgen -W "--output-dir --report --json --list-hashes --filter-stage --filter-reason --filter-gate -v -h --help" -- "$cur") ) ;;
         serve)      COMPREPLY=( $(compgen -W "--output-dir --transport --host --port --auth-token-file -h --help" -- "$cur") ) ;;
@@ -1107,7 +1111,7 @@ _corpus() {
         _describe 'command' verbs
     elif (( CURRENT >= 3 )); then
         case "$words[2]" in
-            run)        _arguments '--dry-run' '--force-rebuild' '--no-vision' '--no-bundle' '--enrich-bhl' ;;
+            run)        _arguments '--dry-run' '--force-rebuild' '--figure-panels:mode:(ocr vision-local vision-claude off)' '--no-vision' '--no-bundle' '--enrich-bhl' ;;
             debug-pdf)  _arguments '--output-dir:DIR:_files -/' '--grobid-url:URL:' '1:PDF:_files' ;;
             status)     _arguments '--output-dir:DIR:_files -/' '--report' '--json' '--list-hashes' ;;
             serve)      _arguments '--output-dir:DIR:_files -/' '--transport' '--host' '--port' '--auth-token-file:FILE:_files' ;;
@@ -1135,6 +1139,7 @@ complete -c corpus -l cite -d 'Print the citation (plain | bibtex)'
 complete -c corpus -s v -d 'verbose (-vv = debug all)'
 complete -c corpus -s q -l quiet
 complete -c corpus -n "__fish_seen_subcommand_from run" -l dry-run -l force-rebuild -l no-vision -l no-bundle -l enrich-bhl
+complete -c corpus -n "__fish_seen_subcommand_from run" -l figure-panels -x -a 'ocr vision-local vision-claude off'
 complete -c corpus -n "__fish_seen_subcommand_from debug-pdf" -l output-dir -l grobid-url
 complete -c corpus -n "__fish_seen_subcommand_from completion" -a 'bash zsh fish'
 """
@@ -1374,8 +1379,25 @@ def _build_parser() -> argparse.ArgumentParser:
                        help="Rebuild only biblio_authority.sqlite (#64)")
     run_p.add_argument("--force-rebuild-taxon-mentions", action="store_true",
                        help="Rebuild only taxon_mentions.sqlite (#64)")
-    run_p.add_argument("--no-vision", action="store_true",
-                       help="Skip the vision pass (Pass 3b)")
+    # Figure panel-ROI detection (#102). The per-run override of the
+    # corpuscle's `figures.panel_detection` config key. `--no-vision` is
+    # the deprecated alias for `--figure-panels ocr`; the two are
+    # mutually exclusive.
+    panels_grp = run_p.add_mutually_exclusive_group()
+    panels_grp.add_argument(
+        "--figure-panels",
+        choices=["ocr", "vision-local", "vision-claude", "off"],
+        default=None,
+        help="Override config `figures.panel_detection` for this run: "
+             "ocr (CPU OCR-panel floor), vision-local / vision-claude "
+             "(Pass 3b vision), or off. Omit to use config.yaml.",
+    )
+    panels_grp.add_argument(
+        "--no-vision", action="store_true",
+        help="Deprecated alias for `--figure-panels ocr`: skip the vision "
+             "pass (Pass 3b) and use the CPU OCR-panel floor instead. Does "
+             "NOT disable panels — pass `--figure-panels off` for that.",
+    )
     run_p.add_argument("--no-bundle", action="store_true",
                        help="Skip the served-bundle distillation step. "
                        "Build artifacts in `<output_dir>/` are unaffected; "

--- a/tests/test_figure_panels_flag.py
+++ b/tests/test_figure_panels_flag.py
@@ -35,8 +35,8 @@ def _cfg(tmp_path: Path, panel_detection="ocr"):
 
 def _run_args(**overrides):
     base = dict(
-        force_rebuild=False, dry_run=False, no_vision=False, enrich_bhl=False,
-        force_rebuild_taxonomy=False, force_rebuild_biblio=False,
+        force_rebuild=False, dry_run=False, no_vision=False, figure_panels=None,
+        enrich_bhl=False, force_rebuild_taxonomy=False, force_rebuild_biblio=False,
         force_rebuild_taxon_mentions=False,
     )
     base.update(overrides)
@@ -80,6 +80,43 @@ def test_usable_vision_mode_is_forwarded(tmp_path, monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
     argv = _argv(tmp_path, "vision-claude")
     assert argv[argv.index("--figure-panels") + 1] == "vision-claude"
+
+
+# --- corpus run --figure-panels override (#102 follow-up) ---------------------
+
+
+def test_run_figure_panels_overrides_config(tmp_path, monkeypatch):
+    """An explicit `corpus run --figure-panels` wins over the config key."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    # config says ocr; the CLI override asks for vision-claude.
+    argv = _argv(tmp_path, "ocr", figure_panels="vision-claude")
+    assert argv[argv.index("--figure-panels") + 1] == "vision-claude"
+
+
+def test_run_figure_panels_off_overrides_config(tmp_path):
+    argv = _argv(tmp_path, "vision-claude", figure_panels="off")
+    assert argv[argv.index("--figure-panels") + 1] == "off"
+
+
+def test_no_vision_is_alias_for_ocr_even_from_off(tmp_path):
+    """`--no-vision` ≡ `--figure-panels ocr`, so it forces the OCR floor
+    even when the config selected `off`."""
+    argv = _argv(tmp_path, "off", no_vision=True)
+    assert argv[argv.index("--figure-panels") + 1] == "ocr"
+
+
+def test_run_rejects_figure_panels_with_no_vision(tmp_path):
+    """The two are mutually exclusive in the `corpus run` parser."""
+    parser = cli._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "--figure-panels", "ocr", "--no-vision"])
+
+
+def test_run_accepts_figure_panels_choice(tmp_path):
+    parser = cli._build_parser()
+    args = parser.parse_args(["run", "--figure-panels", "vision-local"])
+    assert args.figure_panels == "vision-local"
+    assert args.no_vision is False
 
 
 # --- pipeline.main derivation -------------------------------------------------


### PR DESCRIPTION
Resolves the confusion reported on `dev_docs/OVERVIEW.md` vs `corpus run --help`.

## The seam
#102 made figure-panel detection a **`figures.panel_detection`** config key plus the **`--figure-panels`** flag on `pipeline.main`/the orchestrator — but `corpus run` (the user-facing CLI) only kept `--no-vision`. So:
- OVERVIEW referenced `--figure-panels` as *the* control, yet `corpus run --figure-panels` errored (`unrecognized arguments`); the flag only existed on the inner layer `corpus run` shells out to.
- `--no-vision`'s help still said *"Skip the vision pass (Pass 3b)"* — stale: post-#102 it **downgrades to the OCR floor** (still emits OCR `rois`), it doesn't disable panels.
- OVERVIEW's "Optional passes" section still claimed panels are **"off by default"** — true pre-#102, but the default is now `ocr`.

## Fix (chosen approach: add the flag, keep `--no-vision` as alias)
- **`corpus run --figure-panels {ocr,vision-local,vision-claude,off}`** — a per-run override of `figures.panel_detection`. Precedence: `--figure-panels` > `--no-vision` > config key.
- **`--no-vision`** is now a deprecated **alias for `--figure-panels ocr`**, mutually exclusive with `--figure-panels`, with corrected help (downgrades to OCR floor; use `--figure-panels off` to actually disable panels).
- bash/zsh/fish completions gain `--figure-panels` under `run`.
- **OVERVIEW.md** corrected: `ocr` is the default floor (not "off by default"); documents the config key + `corpus run --figure-panels` override + the `pipeline.main`/`slurm` `--figure-panels` plumbing.

## Verification
- `corpus run --help` now shows `[--figure-panels {…} | --no-vision]`; `--figure-panels off` propagates to `pipeline.main … --figure-panels off`; `--figure-panels … --no-vision` together → parser error.
- New tests in `test_figure_panels_flag.py` (override-wins, off-override, `--no-vision`≡ocr-from-off, mutual-exclusion, choice parse).
- **pyflakes clean** (ran the gate locally this time) + full suite **592 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)