### PR TITLE
ci(T1): free runner disk before conda setup to stop ENOSPC flake

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,6 +73,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        # The ubuntu-24.04 runner ships ~25–30 GB of preinstalled
+        # toolchains we never use (Android SDK, .NET, GHC/ghcup, CodeQL).
+        # The conda solve + BGE-M3 model + Grobid service image have
+        # intermittently exhausted the disk at "Set up miniforge" with
+        # `No space left on device`. Reclaim the big unused dirs up front.
+        #
+        # Done as a plain `rm -rf` rather than a third-party action to
+        # keep CI dependency-light (matches the action-pinning hygiene
+        # here) and to avoid any chance of disturbing the running Grobid
+        # `services:` container. Best-effort: missing paths must not fail
+        # the job (`|| true`). No `docker image prune` — Grobid's image
+        # is in use by the live service container.
+        run: |
+          echo "disk before:"; df -h /
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL || true
+          echo "disk after:"; df -h /
+
       - name: Set up miniforge + conda env
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
## Problem
The **ubuntu-24.04 T1 demo-build lane** has intermittently failed at the *"Set up miniforge + conda env"* step with:

```
System.IO.IOException: No space left on device
```

— seen **3×** across recent `dev` pushes (#118/#119 merge, #120 merge, #125). The runner's ~25–30 GB of preinstalled toolchains (Android SDK, .NET, GHC/ghcup, CodeQL) leave too little headroom for the conda solve + BGE-M3 model download + the Grobid service image. T2 (macOS) and T0 are unaffected, which is how we know it's infra, not code.

## Fix
Add a **"Free up disk space"** step right after `Checkout` (before the failing `Set up miniforge`) on the **T1 job only**, that `rm -rf`s the big unused toolchain dirs, logging `df -h /` before/after.

Deliberately a plain `rm -rf` (best-effort `|| true`) rather than a third-party action:
- keeps CI dependency-light, matching the repo's action-pinning hygiene (`@v4`/`@v3`, no `@main`);
- avoids any chance of disturbing the running Grobid `services:` container — and **no `docker image prune`** for the same reason (Grobid's image is in use by the live service).

T2 (macOS) is untouched — it doesn't hit this and has a different disk layout.

## Validation
Workflow YAML parses; the step is inserted as T1 step #2 (`Checkout` → `Free up disk space` → `Set up miniforge`), T2 unchanged. The real proof is this PR's own T1 run going green through conda setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)