### PR TITLE
#122: fold diacritics in author lookup to match surname_normalized

### DIFF
--- a/mcpsrv/indexes.py
+++ b/mcpsrv/indexes.py
@@ -21,6 +21,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from bib.authority import normalize_for_key
 from pipeline.taxa import TaxonomyDB
 from pipeline.embeddings import (
     EmbeddingBackend,
@@ -349,7 +350,10 @@ class CorpusIndex:
                     )
 
             for author in metadata.get("authors", []) or []:
-                surname = (author.get("surname") or "").strip().lower()
+                # #122 — key the Grobid-metadata author index with the
+                # same diacritic-folding normalizer get_papers_by_author
+                # queries with, so "Müller" and "Muller" resolve alike.
+                surname = normalize_for_key(author.get("surname") or "")
                 if surname:
                     self.author_to_papers[surname].append(paper_hash)
 
@@ -538,7 +542,9 @@ class BiblioAuthority:
             FROM works w JOIN work_authors wa ON w.work_id = wa.work_id
             WHERE wa.surname_normalized = ?
         """
-        params: list = [surname.strip().lower()]
+        # #122 — match the diacritic-stripped surname_normalized column
+        # with the same normalizer that built it.
+        params: list = [normalize_for_key(surname)]
         if year:
             query += " AND w.year = ?"
             params.append(year)

--- a/mcpsrv/tools/bibliography.py
+++ b/mcpsrv/tools/bibliography.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from bib.authority import normalize_for_key
+
 from ..app import _load_json, _need_index, error, mcp
 
 if TYPE_CHECKING:
@@ -661,7 +663,11 @@ def get_works_by_author(
     if idx.biblio_db is None:
         return [error("bibliographic authority database not configured", "not_configured")]
 
-    norm = surname.strip().lower()
+    # #122 — the surname_normalized column is built with
+    # normalize_for_key (diacritic-stripped); query with the SAME
+    # normalizer so "Müller" matches "muller". A plain .strip().lower()
+    # leaves the umlaut on and silently returns zero rows.
+    norm = normalize_for_key(surname)
     query = """
         SELECT DISTINCT w.work_id, w.title, w.year, w.journal, w.doi,
                w.in_corpus, w.corpus_hash, w.guid_type

--- a/mcpsrv/tools/taxonomy.py
+++ b/mcpsrv/tools/taxonomy.py
@@ -13,6 +13,8 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from bib.authority import normalize_for_key
+
 from ..app import _load_json, _need_index, _validated_limit, error, mcp
 
 # Filenames at the per-paper root that are NOT lexicon outputs.
@@ -698,7 +700,9 @@ def get_papers_by_author(surname: str) -> List[Dict]:
     get_chunks_for_taxon or get_chunks_by_section.
     """
     idx = _need_index()
-    key = (surname or "").strip().lower()
+    # #122 — normalize with the same diacritic-folding key used to build
+    # author_to_papers (CorpusIndex.load), so "Müller" == "Muller".
+    key = normalize_for_key(surname or "")
     if not key:
         return []
     hashes = idx.author_to_papers.get(key, [])

--- a/tests/test_author_diacritics.py
+++ b/tests/test_author_diacritics.py
@@ -1,0 +1,105 @@
+"""Diacritic-folding author lookup (#122).
+
+`work_authors.surname_normalized` (and the in-memory `author_to_papers`
+index) are built with `bib.authority.normalize_for_key`, which strips
+diacritics. The serve-side author tools used to query with a plain
+`.strip().lower()`, so `get_works_by_author("Müller")` returned 0 while
+`"Muller"` returned the real set. These tests pin that the query side
+now uses the same normalizer:
+
+- `Müller` ≡ `Muller` (both → "muller")
+- `Mueller` stays a distinct surname (normalize_for_key is diacritic-
+  strip, NOT oe-expansion)
+- ASCII-only queries are unchanged (regression guard)
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+from bib.authority import create_schema, normalize_for_key
+from mcpsrv import app as mcp_app
+from mcpsrv.indexes import BiblioAuthority
+from mcpsrv.tools.bibliography import get_works_by_author
+from mcpsrv.tools.taxonomy import get_papers_by_author
+
+
+def _insert_work(conn, work_id, surname, *, forename=None):
+    now = time.time()
+    conn.execute(
+        """INSERT INTO works
+           (work_id, guid_type, title, year, journal, doi, in_corpus,
+            corpus_hash, source, confidence, bib_imported_at,
+            created_at, updated_at)
+           VALUES (?, 'corpus_key', ?, 2010, 'J', NULL, 0, NULL,
+                   'cited_reference', 1.0, NULL, ?, ?)""",
+        (work_id, f"work {work_id}", now, now),
+    )
+    # surname_normalized is populated exactly as the importer does it.
+    conn.execute(
+        """INSERT INTO work_authors
+           (work_id, position, surname, surname_normalized, forename)
+           VALUES (?, 0, ?, ?, ?)""",
+        (work_id, surname, normalize_for_key(surname), forename),
+    )
+
+
+@pytest.fixture
+def index(tmp_path: Path):
+    db_path = tmp_path / "biblio.sqlite"
+    conn = sqlite3.connect(db_path)
+    create_schema(conn)
+    # Two diacritic surnames, one oe-spelled, one ASCII control.
+    _insert_work(conn, "w:muller1", "Müller")
+    _insert_work(conn, "w:muller2", "Müller")
+    _insert_work(conn, "w:mueller1", "Mueller")   # legitimately distinct
+    _insert_work(conn, "w:smith1", "Smith")
+    conn.commit()
+    conn.close()
+
+    fake = types.SimpleNamespace(biblio_db=BiblioAuthority(db_path))
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    yield fake
+    mcp_app.set_index(original)
+
+
+def test_diacritic_and_ascii_spelling_match(index):
+    umlaut = {w["work_id"] for w in get_works_by_author("Müller")}
+    ascii_ = {w["work_id"] for w in get_works_by_author("Muller")}
+    assert umlaut == ascii_ == {"w:muller1", "w:muller2"}
+
+
+def test_oe_spelling_stays_distinct(index):
+    """normalize_for_key strips diacritics; it does NOT expand ü→ue, so
+    'Mueller' must not collapse into the 'Müller' set."""
+    mueller = {w["work_id"] for w in get_works_by_author("Mueller")}
+    assert mueller == {"w:mueller1"}
+    assert "w:muller1" not in mueller
+
+
+def test_ascii_surname_unchanged(index):
+    smith = {w["work_id"] for w in get_works_by_author("Smith")}
+    assert smith == {"w:smith1"}
+
+
+def test_get_papers_by_author_folds_diacritics():
+    """The Grobid-metadata path (author_to_papers) is keyed with the same
+    normalizer, so a diacritic query and its ASCII spelling hit the same
+    key."""
+    fake = types.SimpleNamespace(
+        author_to_papers={normalize_for_key("Müller"): ["hash00000001"]},
+        papers={"hash00000001": {"title": "T", "year": 2010, "authors": []}},
+    )
+    original = mcp_app._INDEX
+    mcp_app.set_index(fake)
+    try:
+        by_umlaut = {p["hash"] for p in get_papers_by_author("Müller")}
+        by_ascii = {p["hash"] for p in get_papers_by_author("Muller")}
+        assert by_umlaut == by_ascii == {"hash00000001"}
+    finally:
+        mcp_app.set_index(original)


### PR DESCRIPTION
Fixes [#122](https://github.com/caseywdunn/corpus/issues/122) (filed by @JMusser499).

## Bug
`get_works_by_author("Müller")` → **0 works**; `get_works_by_author("Muller")` → **439**. The `work_authors.surname_normalized` column (and the in-memory `author_to_papers` index) are built with `bib.authority.normalize_for_key` (NFD diacritic-strip → `"müller"`→`"muller"`), but the serve-side queries used a plain `.strip().lower()` that left the umlaut on, so a diacritic surname never matched the stripped column. Silent — every non-ASCII surname read as "missing from the corpus."

## Fix
Query with the **same normalizer** that built the data, at every author site:
- `mcpsrv/tools/bibliography.py` → `get_works_by_author`
- `mcpsrv/indexes.py` → `BiblioAuthority.search_works` (also fixes diacritic author queries in the citation resolver)
- the Grobid-metadata path, **build + query in lockstep** (so they stay consistent): `author_to_papers` keying in `CorpusIndex.load` + `get_papers_by_author`

`normalize_for_key` is diacritic-strip, **not** oe-expansion — so `Müller ≡ Muller` (both → `"muller"`) while `Mueller` stays a legitimately distinct surname, exactly per the column's own build rule (Jake's acceptance criteria).

**Serve-side query fix only — works against existing bundles with no rebuild.**

## Tests
`tests/test_author_diacritics.py`: diacritic≡ASCII match, oe-spelling stays distinct, ASCII-only unchanged (regression guard), and Grobid-path `get_papers_by_author` parity. pyflakes clean; full suite **596 passed, 77 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)