### PR TITLE
docs: sync OVERVIEW + MCP_TOOLS with the current 39-tool surface

### DIFF
--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -120,7 +120,7 @@ client.messages.create(
 Two breakpoints land below the ~5 k-token cache-eligibility floor on typical bundles:
 
 - **System prompt** (`mcpsrv/default_instructions.md` concatenated with any corpuscle-specific `instructions.md`): ~500–1500 tokens.
-- **Tool catalog** (42 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
+- **Tool catalog** (39 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
 
 Together ~5 k tokens get cached across all turns of a session — a non-trivial saving on conversations that fan out into many tool-use rounds. Cache lives ~5 minutes by default; subsequent sessions against the same build hit the same cache lines.
 

--- a/dev_docs/OVERVIEW.md
+++ b/dev_docs/OVERVIEW.md
@@ -9,7 +9,7 @@ The top-level entry-point scripts are thin shims; the implementation is grouped 
 | Package | Role |
 |---|---|
 | `pipeline/` | Stage 1 + Pass 3b/3c orchestrator and shared library modules. Split into `scan.py` (OCR), `extract.py` (docling), `metadata.py` (Grobid + bib), `chunking.py`, `annotate.py` (taxa + lexicons), `figure_passes.py`, `runner.py` (per-paper orchestrator), `main.py` (CLI), and supporting `config.py` / `io.py` / `log.py` / `stages.py`. Shared library modules: `figures.py`, `taxa.py`, `grobid_client.py`, `embeddings.py`, `vision.py`, `external.py`, `version.py`. |
-| `mcpsrv/` | MCP server. `app.py` defines the FastMCP instance; `tools/{papers,taxonomy,bibliography,figures,chunks,lexicon}.py` register the `@mcp.tool()`-decorated functions (see [MCP_TOOLS.md](MCP_TOOLS.md) for the catalog); `transport.py` handles stdio + SSE; `indexes.py` is the eager in-memory index. |
+| `mcpsrv/` | MCP server. `app.py` defines the FastMCP instance; `tools/{papers,taxonomy,bibliography,figures,chunks,lexicon,profiles}.py` register the `@mcp.tool()`-decorated functions (see [MCP_TOOLS.md](MCP_TOOLS.md) for the catalog); `transport.py` handles stdio + SSE; `indexes.py` is the eager in-memory index. |
 | `bib/` | BibTeX import / export round-trip plus shared metadata helpers (`parser.py`, `importer.py`, `export.py`). |
 | `slurm/` | SLURM batch scripts (Bouchet). |
 | `deploy/` | CloudFormation, nginx config, systemd unit, sync + update shell scripts. |
@@ -179,7 +179,7 @@ Built from per-paper artifacts after Stage 1 finishes. All four are independentl
 
 ## MCP server (`mcpsrv/`)
 
-Exposes the processed corpus as an MCP (Model Context Protocol) server that LLM clients can query. The server is a read-only view over per-paper artifacts; it does not store data of its own. The server entry point [`mcp_server.py`](../mcp_server.py) is a thin shim — the implementation lives in `mcpsrv/`, with the `@mcp.tool()`-decorated functions split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon}.py`. See [MCP_TOOLS.md](MCP_TOOLS.md) for the full tool surface and count.
+Exposes the processed corpus as an MCP (Model Context Protocol) server that LLM clients can query. The server is a read-only view over per-paper artifacts; it does not store data of its own. The server entry point [`mcp_server.py`](../mcp_server.py) is a thin shim — the implementation lives in `mcpsrv/`, with the `@mcp.tool()`-decorated functions split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon,profiles}.py`. See [MCP_TOOLS.md](MCP_TOOLS.md) for the full tool surface and count.
 
 ## Steering the client session
 


### PR DESCRIPTION
Post-v0.6 audit of `slurm/` + docs against the live tool / CLI / config state (prompted by "are slurm scripts and docs current with tool state?").

## SLURM — current, no changes needed
All 8 scripts audited. `batch_pass3b.sh` already uses `--figure-panels vision-local` (the #102 rename); no stale `--vision-backend` / `--content-aware-figures` / `--allow-unpublishable` / `vision.backend` anywhere. `batch_process_corpus.sh` / `batch_embed.sh` use `--resume`, which is still valid.

## Docs — 3 stale spots fixed
- `MCP_TOOLS.md` token-budget note said **"42 tools"** → **39** (the header count was already right; #88 §2.3 dropped 42→39).
- `OVERVIEW.md` repo-layout table **and** MCP-server section listed the tools modules as `{papers,taxonomy,bibliography,figures,chunks,lexicon}` — **missing `profiles`** (the #101 module with `list_output_profiles` / `get_active_profile`).

## Verification
Diffed the `MCP_TOOLS.md` catalog against the live registry: **39 documented rows == 39 registered tools, zero stale, zero missing** — so the per-tool catalog is current (plurals not singulars, dossier/profile tools present, etc.).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)