### PR TITLE
release: bump __version__ to 0.6.0rc1

### DIFF
--- a/pipeline/version.py
+++ b/pipeline/version.py
@@ -9,4 +9,4 @@ keeps this in sync with the git tag and CHANGELOG entry. PEP 440
 pre-release suffixes (`.devN`, `aN`, `rcN`) on `dev` between releases.
 """
 
-__version__ = "0.6.0.dev0"
+__version__ = "0.6.0rc1"


### PR DESCRIPTION
v0.6 **release candidate** off `dev` for full-corpus validation.

- All v0.6 PLAN items + the #121/#122 (Jake) follow-ups are merged and CI-green; CHANGELOG `[Unreleased]` is release-ready.
- PEP 440 `rc` suffix on `dev` per the `pipeline/version.py` + CONTRIBUTING convention.
- **Not** a final release: no `dev → main` merge and no `vX.Y.Z` release tag — this just stamps `0.6.0rc1` into the build artifacts (bundle manifest, `run.log`, `bundle_info`) so a full-corpus run has clean provenance.

Once the candidate validates on a full corpus, the final release follows the CONTRIBUTING ritual (bump to `0.6.0`, merge to `main`, tag `v0.6.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)