### PR TITLE
#124: remove server-side translate_chunk (server stays a thin retrieval layer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,18 +13,24 @@ v0.6 is the **API-freeze** cycle: no new feature tools, instead a
 one-time pass to finalize the public MCP tool surface, fix known
 correctness bugs, and harden ops — because after 1.0 a change to any
 tool default, signature, or response shape is a breaking change. The
-served surface is now **39 MCP tools** with a uniform error payload and
+served surface is now **38 MCP tools** with a uniform error payload and
 a consistent pagination convention; this is the surface 1.0 freezes.
 
 ### Changed (breaking)
 
-- **MCP surface frozen at 39 tools.** The redundant singular tools were
+- **MCP surface frozen at 38 tools.** The redundant singular tools were
   removed in favor of their batched plurals
   ([#88](https://github.com/caseywdunn/corpus/issues/88) §2.3):
   `format_citation` → `format_citations`, `get_paper` → `get_papers`,
   `get_chunk` → `get_chunks` (pass a single-element list for the
   one-item case). `mcpsrv/default_instructions.md` routes citations
   through `format_citations`.
+- **Removed `translate_chunk`** ([#124](https://github.com/caseywdunn/corpus/issues/124)).
+  It was the only server-side LLM-call tool; the MCP server is now a
+  purely deterministic retrieval layer. Translation is an analysis step
+  an MCP client (itself an LLM) does on chunk text it already retrieved
+  via `get_chunks` — it doesn't need a server-side Claude call, key, or
+  cache. Removed pre-1.0 so it isn't frozen into the stable surface.
 - **Breaking response-shape defaults**
   ([#88](https://github.com/caseywdunn/corpus/issues/88) Part 1):
   `lexicon_matrix` returns per-term **summaries by default**
@@ -134,6 +140,7 @@ a consistent pagination convention; this is the surface 1.0 freezes.
 | `format_citation(...)` | `format_citations(queries=[...] / work_ids=[...] / paper_hashes=[...])` |
 | `get_paper(hash)` | `get_papers(hashes=[hash])` |
 | `get_chunk(hash, chunk_id)` | `get_chunks(hash, chunk_ids=[chunk_id])` |
+| `translate_chunk(hash, chunk_id, target_language)` | removed — translate the text from `get_chunks` client-side |
 | citation error token `{"error": "not_found"}` | `{"error": <message>, "code": "not_found"}` (branch on `code`) |
 | `lexicon_matrix()` full grid | summary by default; `lexicon_matrix(detail=True)` for the grid |
 | `get_figures_for_taxon` full `caption_text` | caption preview; `full_caption=True` for verbatim |

--- a/dev_docs/MCP_TOOLS.md
+++ b/dev_docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # MCP tool surface
 
-The MCP server exposes 39 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon,profiles}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
+The MCP server exposes 38 `@mcp.tool()`-decorated functions, split across `mcpsrv/tools/{papers,taxonomy,bibliography,figures,chunks,lexicon,profiles}.py`. The top-level [mcp_server.py](../mcp_server.py) is a thin shim into `mcpsrv.main`.
 
 This table is generated from the docstrings in the source; when the server definition changes, regenerate with:
 
@@ -70,14 +70,13 @@ for f in sorted(pathlib.Path('mcpsrv/tools').glob('*.py')):
 | `list_figure_rois` | Per-panel / per-subfigure ROIs annotated on a figure. |
 | `get_figure_roi_image` | Crop a panel ROI out of a figure image and return the crop's path. |
 
-## Semantic search + translation
+## Semantic search
 
-Requires `embed_chunks.py` to have been run (for `get_chunks_for_topic`) and `ANTHROPIC_API_KEY` (for `translate_chunk`).
+Requires `embed_chunks.py` to have been run (for `get_chunks_for_topic`).
 
 | Tool | Returns |
 | --- | --- |
 | `get_chunks_for_topic` | Semantic search over chunks via the LanceDB vector index. Pass `with_text=False` for a metadata-only scan (#82): ~80 chars/row vs ~600 with full text, then drill down with `get_chunks(paper_hash, chunk_ids=[...])`. Pass `with_cites=True` (#88) to attach `cited_work_ids` (the chunk's parent paper's in-text citation targets) — feed to `format_citations`. |
-| `translate_chunk` | Translate one chunk to the target language (default English), via the Anthropic Claude API. |
 
 ## Output profiles
 
@@ -120,7 +119,7 @@ client.messages.create(
 Two breakpoints land below the ~5 k-token cache-eligibility floor on typical bundles:
 
 - **System prompt** (`mcpsrv/default_instructions.md` concatenated with any corpuscle-specific `instructions.md`): ~500–1500 tokens.
-- **Tool catalog** (39 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
+- **Tool catalog** (38 tools × ~100 tokens after the #81 docstring trim): ~4 k tokens.
 
 Together ~5 k tokens get cached across all turns of a session — a non-trivial saving on conversations that fan out into many tool-use rounds. Cache lives ~5 minutes by default; subsequent sessions against the same build hit the same cache lines.
 

--- a/mcpsrv/tools/chunks.py
+++ b/mcpsrv/tools/chunks.py
@@ -1,13 +1,15 @@
 """Chunk-level MCP tools.
 
-Surfaces: get_chunks_by_section (Grobid-section-typed retrieval),
-get_chunks_for_topic (semantic search via the LanceDB vector index),
-translate_chunk (Claude-driven on-demand translation, currently the
-only LLM-call tool in the surface).
+Surfaces: get_chunks (batched chunk fetch for one paper),
+get_chunks_by_section (Grobid-section-typed retrieval), and
+get_chunks_for_topic (semantic search via the LanceDB vector index).
+
+The server has no LLM-call tools — it is a deterministic retrieval
+layer (#124). The former server-side `translate_chunk` was removed
+pre-1.0; an MCP client translates retrieved chunk text itself.
 """
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -115,132 +117,6 @@ def get_chunks_by_section(
             row["len_chars"] = len(text)
         rows.append(row)
     return rows[:n]
-
-
-
-@mcp.tool()
-def translate_chunk(
-    paper_hash: str,
-    chunk_id: str,
-    target_language: str = "en",
-    model: str = "claude-haiku-4-5-20251001",
-) -> Dict:
-    """Translate one chunk to the target language (default English) via
-    the Anthropic Claude API. Cached server-side per chunk so repeats
-    are free. If the chunk is already in the target language, returns
-    the original with ``translation_needed: False``. Requires
-    ``ANTHROPIC_API_KEY``.
-    """
-    idx = _need_index()
-    p = idx.papers.get(paper_hash)
-    if not p:
-        return error(f"no such paper_hash: {paper_hash}", "not_found")
-    hash_dir = Path(p["hash_dir"])
-
-    # Find the chunk text.
-    chunks = _load_json(hash_dir / "chunks.json", default={}) or {}
-    chunk = next((c for c in chunks.get("chunks", []) or [] if c.get("chunk_id") == chunk_id), None)
-    if chunk is None:
-        return error(
-            f"no such chunk_id {chunk_id!r} in paper {paper_hash}", "not_found",
-        )
-    original = chunk.get("text") or ""
-
-    # If the paper's detected_language already matches, no translation
-    # needed. Short-circuit so the user doesn't pay a Claude call to get
-    # the same bytes back.
-    scan = _load_json(hash_dir / "scan_detection.json", default={}) or {}
-    src_lang = scan.get("detected_language")
-    if src_lang and src_lang.lower() == target_language.lower():
-        return {
-            "paper_hash": paper_hash,
-            "chunk_id": chunk_id,
-            "source_language": src_lang,
-            "target_language": target_language,
-            "translation_needed": False,
-            "original": original,
-            "translation": original,
-            "cached": False,
-        }
-
-    # Check the on-disk cache first.
-    cache_file = hash_dir / f"translated_{target_language}.json"
-    cache = _load_json(cache_file, default={}) or {}
-    if chunk_id in cache:
-        hit = cache[chunk_id]
-        return {
-            "paper_hash": paper_hash,
-            "chunk_id": chunk_id,
-            "source_language": src_lang,
-            "target_language": target_language,
-            "translation_needed": True,
-            "original": original,
-            "translation": hit.get("translation", ""),
-            "cached": True,
-            "model": hit.get("model"),
-        }
-
-    # Translate via Claude.
-    try:
-        import anthropic
-    except ImportError:
-        return error(
-            "anthropic package not installed (pip install anthropic)",
-            "unavailable",
-        )
-    import os
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        return error("ANTHROPIC_API_KEY not set in environment", "not_configured")
-
-    client = anthropic.Anthropic()
-    # Short prompt because Claude handles translation well without
-    # elaborate instruction. Preserve scientific names (Latin binomials,
-    # taxonomic authorities) and quoted terms verbatim — these carry
-    # technical meaning that paraphrase would degrade.
-    system_prompt = (
-        f"Translate the following scientific text into {target_language}. "
-        "Preserve any Latin scientific names, taxonomic authorities "
-        "(e.g., 'Eschscholtz, 1829'), and terms in quotation marks "
-        "exactly as written. Return only the translation — no preface, "
-        "no commentary, no source-text repetition."
-    )
-    try:
-        response = client.messages.create(
-            model=model,
-            max_tokens=max(512, min(4096, len(original))),
-            system=system_prompt,
-            messages=[{"role": "user", "content": original}],
-        )
-    except Exception as e:
-        return error(f"Claude API call failed: {e}", "unavailable")
-
-    # Extract the text block from the response.
-    translated_text = ""
-    for block in response.content:
-        if getattr(block, "type", None) == "text":
-            translated_text += block.text or ""
-    translated_text = translated_text.strip()
-
-    # Persist to cache.
-    cache[chunk_id] = {
-        "translation": translated_text,
-        "model": model,
-        "source_language": src_lang,
-    }
-    with cache_file.open("w", encoding="utf-8") as f:
-        json.dump(cache, f, indent=2, ensure_ascii=False)
-
-    return {
-        "paper_hash": paper_hash,
-        "chunk_id": chunk_id,
-        "source_language": src_lang,
-        "target_language": target_language,
-        "translation_needed": True,
-        "original": original,
-        "translation": translated_text,
-        "cached": False,
-        "model": model,
-    }
 
 
 

--- a/tests/test_freeze_contract.py
+++ b/tests/test_freeze_contract.py
@@ -3,7 +3,7 @@
 Pins the MCP tool surface that 1.0 freezes, so any drift is a deliberate,
 reviewed edit rather than an accident:
 
-1. The exact set of registered tool names (39).
+1. The exact set of registered tool names (38).
 2. The pagination-naming convention — single-knob tools use ``limit``;
    only the documented multi-cap dossier/graph tools use ``max_*``.
 3. The uniform error payload — every tool error return carries a human
@@ -40,7 +40,6 @@ EXPECTED_TOOLS = frozenset({
     "get_taxon_subtree_dossier", "get_works_by_author", "lexicon_matrix",
     "list_figure_rois", "list_output_profiles", "list_papers",
     "list_valid_species_under", "resolve_reference", "search_taxon",
-    "translate_chunk",
 })
 
 # The documented exception to "``limit`` everywhere": tools where one call
@@ -78,8 +77,8 @@ def test_registered_tool_surface_is_frozen():
     )
 
 
-def test_tool_count_is_39():
-    assert len(_registered()) == 39
+def test_tool_count_is_38():
+    assert len(_registered()) == 38
 
 
 def test_removed_singular_tools_stay_removed():


### PR DESCRIPTION
Per the #124 decision — keep the MCP server a thin, deterministic retrieval layer — remove `translate_chunk`, its only server-side LLM-call tool. Doing it **pre-1.0**, since after the freeze it would be a breaking change needing a deprecation cycle.

## Why
- **Analysis, not retrieval.** An MCP client is itself an LLM; it can translate the chunk text it already fetched via `get_chunks` — no server-side Claude call, `ANTHROPIC_API_KEY`, or per-chunk cache. That's exactly the "do it client-side" category from #124.
- It was **never in `default_instructions.md`**, so the served LLM was never told to call it → low blast radius.
- Keeping it would freeze a "thin server, except this one LLM tool" exception into the 1.0 surface.

## Surface 39 → 38
- Delete the tool + drop the now-unused `import json`; `chunks.py` module docstring now states the server has no LLM-call tools.
- `tests/test_freeze_contract.py`: `EXPECTED_TOOLS` − `translate_chunk`, count test → 38.
- `MCP_TOOLS.md`: count, catalog row, and the `ANTHROPIC_API_KEY` note.
- CHANGELOG breaking-changes + migration row (`translate_chunk` → translate client-side).

Live registry = 38, freeze contract green, pyflakes clean, full suite **607 passed**.

**Gates the RC:** the `0.6.0rc1` version bump (#133) will be rebased on top of this so the candidate ships the 38-tool surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)