### PR TITLE
docs(bouchet): set HF_HUB_DISABLE_IMPLICIT_TOKEN in pre-download (#97)

### DIFF
--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -66,6 +66,11 @@ Do this once on an interactive node (login nodes usually block outbound internet
 # re-download them (the "Stale HF_HOME" pitfall below).
 export HF_HOME="$BOUCHET_PROJECT/cache/huggingface"
 export TRANSFORMERS_CACHE="$HF_HOME/hub"
+# Silence the implicit-token warning (#97). The batch jobs get this for
+# free (it's set in pipeline/__init__.py on import), but these python -c
+# one-liners import sentence_transformers/transformers directly and skip
+# that, so set it here too.
+export HF_HUB_DISABLE_IMPLICIT_TOKEN=1
 
 # BGE-M3 (embeddings) — ~2 GB
 python -c "from sentence_transformers import SentenceTransformer; \


### PR DESCRIPTION
Follow-up to the BOUCHET HF-cache edit, prompted by "what about #97?".

The #97 fix sets `HF_HUB_DISABLE_IMPLICIT_TOKEN=1` once at import in `pipeline/__init__.py:84`, so every batch job that imports `pipeline` (`python -m pipeline.main`, `embed_chunks.py`, …) gets it and stays warning-free. But the BOUCHET **pre-download one-liners import `sentence_transformers` / `transformers` directly** — they never load `pipeline/__init__.py`, so they don't pick up the fix and can still print the implicit-token warning during the interactive pre-download.

Set the var in the pre-download export block (next to `HF_HOME`) so the manual step matches the batch jobs. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)