### PR TITLE
corpus run: HPC phases + array slicing (--only / --batch-index) [1/3]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,25 @@ Orientation for AI coding agents working in this repository.
 
 A workflow for interrogating a corpus of scientific literature PDFs, spanning both scanned/old and born-digital papers. Target use cases: searching, citation analysis, and collecting figures of the same species across different papers. Corpus-agnostic by design — the group-specific data (taxonomy snapshot, lexicon, BibTeX, instructions) lives in the per-instance corpuscle directory; the lab's reference deployment is a siphonophore corpus, but every other group plugs into the same machinery.
 
+## Documentation scope
+
+Corpus is group-agnostic. The general documentation applies to any corpus and any
+cluster. The siphonophore / Bouchet files are one worked example — **do not treat
+them as requirements or as the only supported workflow**.
+
+| File | Scope | Notes |
+|---|---|---|
+| `README.md`, `INSTALL.md`, `DEPLOY.md` | General | Any corpus, any platform |
+| `dev_docs/OVERVIEW.md`, `dev_docs/PLAN.md`, `dev_docs/MCP_TOOLS.md` | General | Architecture, roadmap, tool reference |
+| `dev_docs/TESTING.md` | General | Quality test suite (ground truth, eval workflow) |
+| `tools/smoke_test_sse.py` | General | Programmatic MCP smoke test; works on any corpuscle. Requires a compute node (not login) for full Layer 3 coverage — Layer 3 loads the ~600 MB BGE-M3 embedder for semantic search. |
+| `dev_docs/BOUCHET.md` | **Siphonophore + Yale Bouchet (example)** | Runbook for the Dunn-lab siphonophore corpus on Yale's Bouchet HPC. The SLURM scripts, paths, and partition names are Bouchet-specific; the pattern (config-driven `corpus run`, job arrays, pre-download models) is general. Use as a template, not a literal guide. |
+| `dev_docs/ACCEPTANCE_PROMPTS.md` | **Siphonophore (example)** | Manual acceptance prompts for the siphonophore corpuscle. Taxon names are siphonophore-specific; adapt for other groups. Referenced from BOUCHET.md. |
+
+When authoring documentation for a new corpus or cluster, add analogues to
+`BOUCHET.md` / `ACCEPTANCE_PROMPTS.md` in your own runbook file — don't modify the
+general docs to embed group-specific details.
+
 ## Documentation map
 
 - [README.md](README.md) — installation, usage, MCP server setup, examples
@@ -14,7 +33,8 @@ A workflow for interrogating a corpus of scientific literature PDFs, spanning bo
 - [dev_docs/PLAN.md](dev_docs/PLAN.md) — roadmap and design decisions for the active version
 - [dev_docs/OVERVIEW.md](dev_docs/OVERVIEW.md) — pipeline architecture, stage internals, figure pipeline, key files
 - [dev_docs/MCP_TOOLS.md](dev_docs/MCP_TOOLS.md) — full MCP tool surface + count
-- [dev_docs/BOUCHET.md](dev_docs/BOUCHET.md) — HPC operational runbook (SLURM, Grobid, job arrays)
+- [dev_docs/BOUCHET.md](dev_docs/BOUCHET.md) — HPC runbook for siphonophore corpus on Yale Bouchet (example; adapt for other clusters/corpora)
+- [dev_docs/ACCEPTANCE_PROMPTS.md](dev_docs/ACCEPTANCE_PROMPTS.md) — manual acceptance prompts for the siphonophore corpuscle (example; adapt taxon names)
 - [DEPLOY.md](DEPLOY.md) — AWS deploy runbook (S3 bundle + EC2 systemd)
 - [dev_docs/TESTING.md](dev_docs/TESTING.md) — quality test suite, ground truth format, evaluation workflow
 - [INSTALL.md](INSTALL.md) — optional OCR extras, pip-only fallback, platform notes

--- a/dev_docs/ACCEPTANCE_PROMPTS.md
+++ b/dev_docs/ACCEPTANCE_PROMPTS.md
@@ -1,9 +1,21 @@
 # Siphonophore Corpus — MCP Acceptance Prompt Checklist
 
+> **Scope: siphonophore corpus, Yale Bouchet HPC (example)**
+> This file is specific to the Dunn-lab siphonophore corpuscle.  It is an
+> example of how to write acceptance prompts for a corpus; taxon names,
+> author names, and paper titles are siphonophore-specific.  To test a
+> different corpus, copy this file and substitute appropriate names.  The
+> general-purpose programmatic smoke test (corpus-agnostic) lives in
+> [`tools/smoke_test_sse.py`](../tools/smoke_test_sse.py).  See also
+> [BOUCHET.md](BOUCHET.md) for HPC-specific run instructions.
+
 A set of realistic natural-language prompts for manual (or Claude-assisted) acceptance
 testing of the siphonophore corpus MCP server.  Run these in order against the live
 server after a new corpuscle build to confirm that all databases, indexes, and tool
 paths are working correctly.
+
+Run on an interactive compute node (`salloc`); the server loads the ~600 MB
+BGE-M3 embedding model on the first semantic search prompt.
 
 Each prompt names the **primary tool(s)** it exercises and lists observable **pass
 criteria** — things a human tester can confirm without domain expertise.

--- a/dev_docs/ACCEPTANCE_PROMPTS.md
+++ b/dev_docs/ACCEPTANCE_PROMPTS.md
@@ -1,0 +1,307 @@
+# Siphonophore Corpus — MCP Acceptance Prompt Checklist
+
+A set of realistic natural-language prompts for manual (or Claude-assisted) acceptance
+testing of the siphonophore corpus MCP server.  Run these in order against the live
+server after a new corpuscle build to confirm that all databases, indexes, and tool
+paths are working correctly.
+
+Each prompt names the **primary tool(s)** it exercises and lists observable **pass
+criteria** — things a human tester can confirm without domain expertise.
+
+> **Tip:** connect Claude to the MCP server (e.g. via the Claude desktop app or
+> `claude --mcp-config`) and paste each prompt verbatim.  A production corpus built
+> from 1 700+ papers should satisfy all pass criteria.
+
+---
+
+## 1  Corpus orientation
+
+**Prompt:**
+> How many papers are in this corpus?  How many text chunks?  Give me a one-paragraph
+> summary of the bundle.
+
+**Tools:** `bundle_info`, `corpus_summary`
+
+**Pass criteria:**
+- Paper count is in the right order of magnitude (≥ 100 for any real build).
+- Chunk count is reported and is larger than the paper count.
+- Bundle name / version present in the response.
+
+---
+
+## 2  List and paginate papers
+
+**Prompt:**
+> List the ten oldest papers in the corpus by year.
+
+**Tools:** `list_papers`
+
+**Pass criteria:**
+- Returns exactly 10 papers with titles, authors, and years.
+- Earliest year is plausibly old (pre-1900 papers exist in this corpus).
+
+---
+
+## 3  Taxonomy — species lookup
+
+**Prompt:**
+> What is the accepted name and taxonomic rank of *Physalia physalis*?  Who described
+> it originally, and in what year?
+
+**Tools:** `search_taxon`, `get_original_description`
+
+**Pass criteria:**
+- Accepted name returned (likely *Physalia physalis* or a synonym note).
+- Rank is "Species".
+- `get_original_description` returns an authorship string containing a year.
+
+---
+
+## 4  Taxon dossier — workhorse tool
+
+**Prompt:**
+> Give me a full dossier on *Nanomia bijuga*: how many corpus papers mention it, which
+> papers have the most mentions, what anatomy terms co-occur most often, and whether
+> any figures are associated with it.
+
+**Tools:** `get_taxon_dossier`
+
+**Pass criteria:**
+- Response contains `taxon`, `papers`, `lexicon_aggregated`, and `figure_index` sections.
+- At least one paper is listed.
+- Anatomy terms appear if the lexicon is configured (category `anatomy` present).
+
+---
+
+## 5  Species inventory
+
+**Prompt:**
+> List all valid species in the order Siphonophorae that appear in this corpus.
+
+**Tools:** `list_valid_species_under`, `get_papers_for_taxon`
+
+**Pass criteria:**
+- Returns a list of species-rank taxa; at least several dozen entries for a full build.
+- No Python errors; "not found" is acceptable on a demo corpus.
+
+---
+
+## 6  Subtree dossier
+
+**Prompt:**
+> Summarise the literature coverage for the family Physaliidae: how many species, how
+> many papers, and which species has the most corpus mentions?
+
+**Tools:** `get_taxon_subtree_dossier`
+
+**Pass criteria:**
+- Response contains species list and per-species paper/mention counts.
+- Top species is plausibly *Physalia physalis*.
+
+---
+
+## 7  Semantic search
+
+**Prompt:**
+> Find the five most relevant text passages about nectophore swimming kinematics.
+
+**Tools:** `get_chunks_for_topic`
+
+**Pass criteria:**
+- Returns 5 chunks (or fewer if corpus is small).
+- Each chunk contains a `text` field with multiple sentences.
+- Passages are thematically related to swimming / nectophores.
+
+---
+
+## 8  Section-based reading
+
+**Prompt:**
+> Show me the Methods section of the paper by Dunn et al. on siphonophore phylogenetics.
+
+**Tools:** `list_papers`, `get_chunks_by_section`
+
+**Pass criteria:**
+- Correct paper hash is retrieved via `list_papers`.
+- `get_chunks_by_section` returns chunks with section headings containing "Method" or
+  "Material".
+- Text is coherent prose (not garbled OCR).
+
+---
+
+## 9  Citation list for a paper
+
+**Prompt:**
+> Give me the full reference list for the Huxley 1859 paper, and tell me which of
+> those cited works are also in this corpus.
+
+**Tools:** `list_papers`, `get_bibliography`
+
+**Pass criteria:**
+- Reference list is non-empty.
+- Each reference has an author string and (usually) a year.
+- The `in_corpus` boolean is present on each reference.
+- At least some references have `in_corpus: true` in a full build.
+
+---
+
+## 10  In-text citation context
+
+**Prompt:**
+> In the Huxley 1859 paper, show me the first ten in-text citation markers and the
+> paragraphs they appear in.
+
+**Tools:** `get_intext_citations`
+
+**Pass criteria:**
+- Response contains `citations` and `paragraphs` lists.
+- Each citation has a `surface` string (the cited text as it appears in the paper).
+- `para_index` values correctly index into the returned `paragraphs` list.
+
+---
+
+## 11  Cross-corpus citation retrieval
+
+**Prompt:**
+> Find every passage in the corpus that cites Huxley's 1859 paper on siphonophores.
+> Show me the citing paper titles and the surrounding text.
+
+**Tools:** `get_works_by_author`, `get_excerpts_citing`
+
+**Pass criteria:**
+- `get_works_by_author("Huxley")` returns at least one result.
+- `get_excerpts_citing` returns passages with `citing_paper_title` and `paragraph` fields.
+- At least one excerpt text mentions "Huxley" or a related concept.
+
+---
+
+## 12  Citation graph
+
+**Prompt:**
+> How many times is the Dunn 2005 siphonophore phylogeny paper cited within this corpus?
+> Which papers cite it most?
+
+**Tools:** `get_citation_graph`
+
+**Pass criteria:**
+- Response includes a `cited_by` count.
+- `citing_papers` list is non-empty if the paper is present in the corpus.
+
+---
+
+## 13  Anatomy lexicon co-occurrence
+
+**Prompt:**
+> Show me the anatomy term co-occurrence matrix for the top 10 terms, limited to the
+> 20 most-relevant papers.  Which terms appear together most often?
+
+**Tools:** `lexicon_matrix`
+
+**Pass criteria:**
+- Response contains `terms`, `papers`, and `matrix` (or equivalent) fields.
+- Matrix has non-zero entries.
+- Term names are recognisable siphonophore anatomy vocabulary (e.g. nectophore,
+  pneumatophore, gastrozooid).
+
+---
+
+## 14  Lexicon term dossier
+
+**Prompt:**
+> Give me a dossier for the anatomy term "nectophore": which papers use it most, in
+> what sections, and are there associated figures?
+
+**Tools:** `get_lexicon_term_dossier`
+
+**Pass criteria:**
+- Response contains a papers list and section breakdown.
+- Figure list present (may be empty on demo corpus).
+- Top papers by mention count seem domain-appropriate.
+
+---
+
+## 15  Figures for a taxon
+
+**Prompt:**
+> Show me figures associated with *Physalia* across the corpus.  For the first result,
+> describe what the figure caption says.
+
+**Tools:** `get_figures_for_taxon`, `get_figure`
+
+**Pass criteria:**
+- `get_figures_for_taxon` returns at least one figure record with `paper_hash`,
+  `figure_id`, and a caption excerpt.
+- `get_figure` retrieves full metadata for that figure including `caption` text.
+
+---
+
+## 16  Figure dossier (visual survey)
+
+**Prompt:**
+> Give me a visual survey of *Nanomia bijuga* figures across the corpus: thumbnails or
+> captions grouped by figure type (diagram, photo, etc.).
+
+**Tools:** `get_figure_dossier_for_taxon`
+
+**Pass criteria:**
+- Response groups figures by `figure_type`.
+- At least one figure type group is non-empty.
+- Caption text is legible and mentions the taxon name.
+
+---
+
+## 17  Output profiles
+
+**Prompt:**
+> What output profiles are configured for this server?  Which one is currently active?
+
+**Tools:** `list_output_profiles`, `get_active_profile`
+
+**Pass criteria:**
+- At least one profile listed.
+- Active profile name returned.
+
+---
+
+## 18  End-to-end: researcher workflow
+
+**Prompt:**
+> I'm researching the evolution of the nectophore across siphonophore families.
+> Point me to the most relevant papers, the key anatomy terms that co-occur with
+> "nectophore", and any figures that show nectophore morphology.
+
+**Tools:** `get_chunks_for_topic`, `get_taxon_dossier` (on Siphonophorae),
+`lexicon_matrix`, `get_figures_for_lexicon_term`
+
+**Pass criteria:**
+- Semantic search returns coherent passages about nectophore biology.
+- Anatomy lexicon highlights terms like "nectosac", "velum", "ostium".
+- At least one figure caption mentions morphological features.
+- Response reads as a useful research starting point, not a list of errors.
+
+---
+
+## Running as a checklist
+
+For each prompt, record:
+
+| # | Tool(s) hit | Pass? | Notes |
+|---|-------------|-------|-------|
+| 1 | bundle_info, corpus_summary | ☐ | |
+| 2 | list_papers | ☐ | |
+| 3 | search_taxon, get_original_description | ☐ | |
+| 4 | get_taxon_dossier | ☐ | |
+| 5 | list_valid_species_under | ☐ | |
+| 6 | get_taxon_subtree_dossier | ☐ | |
+| 7 | get_chunks_for_topic | ☐ | |
+| 8 | get_chunks_by_section | ☐ | |
+| 9 | get_bibliography | ☐ | |
+| 10 | get_intext_citations | ☐ | |
+| 11 | get_works_by_author, get_excerpts_citing | ☐ | |
+| 12 | get_citation_graph | ☐ | |
+| 13 | lexicon_matrix | ☐ | |
+| 14 | get_lexicon_term_dossier | ☐ | |
+| 15 | get_figures_for_taxon, get_figure | ☐ | |
+| 16 | get_figure_dossier_for_taxon | ☐ | |
+| 17 | list_output_profiles, get_active_profile | ☐ | |
+| 18 | (multi-tool) | ☐ | |

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -128,7 +128,7 @@ have internet) before the first pipeline submission:
 
 ```bash
 conda activate corpus
-corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy ingest --source worms
+corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy ingest --source worms --root-id 1371
 # → writes siphonophore_corpuscle/taxonomy.sqlite (~700 KB, takes ~1–2 min)
 ```
 
@@ -156,7 +156,13 @@ significantly, regenerate with `--source worms` and re-export.
 
 ### 4b. Pre-download HuggingFace models
 
-Do this once on an interactive node (login nodes usually block outbound internet; request a compute node with `salloc -p interactive -t 0:30:00`):
+Do this once on an interactive compute node. Login nodes allow small outbound API calls (WoRMS REST, git, pip) but block large binary downloads — HuggingFace model fetches hit that limit and must run on a compute node:
+
+```bash
+salloc -p devel -t 1:00:00 --mem=8G
+```
+
+Once on the node:
 
 ```bash
 # Pre-download into the SAME cache the batch jobs read —
@@ -399,7 +405,7 @@ Each script runs `corpus -c "$CORPUS_CONFIG" run --only <phase>`. Adjust walltim
 
 ## Common pitfalls
 
-- **Login nodes can't download models.** HF and other downloads must run on a compute node via `salloc`. Trying to pre-cache from a login node will hit outbound-firewall blocks.
+- **Login nodes block large binary downloads.** Small outbound API calls (WoRMS REST, git, pip) work fine on the login node. HuggingFace model fetches (~2–15 GB) hit the outbound-size limit and must run on a compute node via `salloc`. Trying to pre-cache models from a login node will fail silently or with a firewall error.
 - **Stale `HF_HOME`.** If a job re-downloads a model, `HF_HOME` isn't being honored — check that the export in the SLURM script points to a path you actually populated.
 - **Grobid URL.** SLURM compute nodes can't talk to your laptop's `localhost:8070` — `$GROBID_URL` (which overrides the config's `grobid.url`) must resolve to a host visible from the job's node. If the Grobid node goes down mid-run, subsequent papers get placeholder metadata; a re-run's implicit resume won't retry them unless their inputs changed — force it with `corpus run --only extract --re-process-flagged <gate>` or by deleting the affected `metadata.json`.
 - **Config not found / wrong corpuscle.** Every phase script reads `$CORPUS_CONFIG`. If a job dies with "no config.yaml" or builds the wrong tree, confirm `$CORPUS_CONFIG` points at the intended `config.yaml` (default is the production corpuscle; a leftover `export CORPUS_CONFIG=…sample…` from a smoke test will silently redirect a production submit).

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -27,11 +27,22 @@ git lfs pull                              # ~2000 PDFs, several GB
 Resulting layout (all under `$BOUCHET_PROJECT`):
 
 ```
-corpus/             ← this repo
-siphonophores/      ← input PDF tree
-output/             ← created by stage 1
-cache/huggingface/  ← model cache (see below)
+corpus/                       ← this repo (the `corpus` CLI)
+siphonophores/                ← input PDF tree + siphonophores.bib + lexicon.yaml
+siphonophore_corpuscle/       ← the corpuscle: config.yaml + build artifacts
+  config.yaml                 ← authored in step 3 (the source of truth)
+  documents/<HASH>/…          ← per-paper artifacts (created by extract)
+  *.sqlite, vector_db/        ← cross-paper DBs + LanceDB (created by embed/post)
+  _serve/                     ← distilled served bundle (created by bundle)
+cache/huggingface/            ← model cache (see below)
 ```
+
+As of #138 the SLURM phase scripts drive the **same `corpus run` CLI**
+users run, one phase per job. All per-corpuscle inputs (PDF dir, BibTeX,
+lexicon, taxonomy source, Grobid) live in `siphonophore_corpuscle/config.yaml`
+— **not** as CLI flags or env vars. The scripts reference it through
+`$CORPUS_CONFIG` (default `$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml`,
+set in [slurm/bouchet_paths.sh](../slurm/bouchet_paths.sh)).
 
 ### 2. Conda environment
 
@@ -54,7 +65,60 @@ pip install torch==2.9.0 torchvision==0.24.0 \
 
 Verify with `python -c "import torch; print(torch.__version__, torch.cuda.is_available())"` on a `gpu` or `gpu_h200` node — should print `2.9.0+cu128 True`. The Stage 1 batch script's preflight (`slurm/batch_process_corpus.sh`) aborts loudly if torch / docling can't import, so a botched install fails fast instead of producing mis-structured output.
 
-### 3. Pre-download HuggingFace models
+### 3. Author the corpuscle config.yaml
+
+This is the source of truth for the build — `corpus run` reads every
+per-corpuscle input from it. Scaffold it once, then edit:
+
+```bash
+conda activate corpus
+mkdir -p "$BOUCHET_PROJECT/siphonophore_corpuscle"
+cd "$BOUCHET_PROJECT/siphonophore_corpuscle"
+corpus init                              # drops a commented config.yaml here
+```
+
+Edit `config.yaml` so it points at the siphonophores repo. Paths resolve
+**relative to the config file's directory** (here, `siphonophore_corpuscle/`),
+so the `../siphonophores/...` paths below work regardless of
+`$BOUCHET_PROJECT` (YAML has no env-var expansion — keep them relative or
+write absolute literals):
+
+```yaml
+# $BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml
+input_pdfs: ../siphonophores/library          # the PDF tree (was $INPUT_DIR)
+output_dir: .                                 # artifacts land here in the
+                                              #   corpuscle dir (= old $OUTPUT_DIR);
+                                              #   keeps resume pointed at any
+                                              #   existing documents/<HASH>/ tree
+bib: ../siphonophores/siphonophores.bib       # was $BIB_FILE
+lexicon: ../siphonophores/lexicon.yaml        # was $LEXICON
+
+taxonomy:                                     # Siphonophorae, WoRMS AphiaID 1371
+  source: worms
+  root_id: 1371
+
+figures:
+  panel_detection: vision-local               # Pass 3b uses local Qwen2.5-VL
+
+grobid:
+  url: http://localhost:8070                  # overridden at submit time by
+                                              #   $GROBID_URL (see step 5 / #138)
+```
+
+Validate it before submitting anything — `corpus check` confirms the host
+can run the build and the config parses; `corpus run --dry-run` plans the
+phases without writing artifacts:
+
+```bash
+corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" check
+corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" run --dry-run
+```
+
+`$CORPUS_CONFIG` already defaults to this path in `bouchet_paths.sh`, so the
+phase scripts find it with no extra flags. To build a *different* corpuscle,
+export `CORPUS_CONFIG=/path/to/other/config.yaml` before submitting.
+
+### 4. Pre-download HuggingFace models
 
 Do this once on an interactive node (login nodes usually block outbound internet; request a compute node with `salloc -p interactive -t 0:30:00`):
 
@@ -112,9 +176,9 @@ revision=...)` and record it — and/or set `HF_HUB_OFFLINE=1` in the batch
 environment so a job can never reach out and pull a newer revision: it
 uses exactly the snapshot cached here or fails loudly.
 
-### 4. Grobid as a Singularity service
+### 5. Grobid as a Singularity service
 
-Grobid is stage 1's bibliographic + section-structure extractor. The `docker-compose.yml` in this repo targets macOS dev; on Bouchet run it via Singularity:
+Grobid is the extract phase's bibliographic + section-structure extractor. The `docker-compose.yml` in this repo targets macOS dev; on Bouchet run it via Singularity:
 
 ```bash
 cd "$BOUCHET_PROJECT/cache"
@@ -126,44 +190,53 @@ salloc -p day -c 4 --mem=16G -t 24:00:00 \
     singularity run --bind "$BOUCHET_PROJECT" grobid.sif
 # …returns a URL like http://<compute_node>:8070
 
-# In a second terminal, submit stage 1 pointing at it:
+# In a second terminal, submit the extract phase pointing at it. The
+# extract script reads input/output/bib/lexicon from $CORPUS_CONFIG;
+# $GROBID_URL overrides the config's grobid.url for this dynamically-
+# allocated node (#138). Exported only when set, so config.yaml stays
+# authoritative on standalone submits.
 export GROBID_URL=http://<compute_node>:8070
 sbatch slurm/batch_process_corpus.sh
 ```
 
-Alternative: run Grobid in the same job as stage 1 by adding `singularity exec ... &` before the `python process_corpus.py` call, with a loop that waits for `/api/isalive`. More brittle; the two-job approach above is cleaner.
+In practice you don't submit Grobid by hand — `slurm/batch_pipeline.sh`
+(see [Production run](#production-run)) starts it, discovers the node,
+waits for `/api/isalive`, exports `$GROBID_URL` into the extract job, and
+tears Grobid down afterward.
 
 ## Dry run (20–50 papers) before the full corpus
 
-Before committing to the 2000-paper run, smoke-test the pipeline end-to-end on a small sample:
+Before committing to the 2000-paper run, smoke-test end-to-end on a small
+sample. Under the config-driven flow (#138) a sample is just a second
+corpuscle — its own directory + `config.yaml` pointing at a slice of PDFs —
+selected by exporting `CORPUS_CONFIG`:
 
 ```bash
-# Pick a subset by copying a slice of the input tree
-mkdir -p "$BOUCHET_PROJECT/siphonophores_sample"
-# …copy ~30 PDFs spanning born-digital modern + historical scans +
-#    German Fraktur to exercise the OCR / language / figure paths
+# 1. A handful of PDFs spanning born-digital modern + historical scans +
+#    German Fraktur to exercise the OCR / language / figure paths.
+mkdir -p "$BOUCHET_PROJECT/siphonophores_sample/library"
+# …copy ~30 PDFs into siphonophores_sample/library/
 
-# Override the defaults from slurm/bouchet_paths.sh via --export.
-SAMPLE_IN="$BOUCHET_PROJECT/siphonophores_sample"
-SAMPLE_OUT="$BOUCHET_PROJECT/output_sample"
+# 2. A sample corpuscle config. Copy the real one and repoint input_pdfs;
+#    output_dir: . keeps the sample's artifacts out of the production tree.
+mkdir -p "$BOUCHET_PROJECT/siphonophore_sample_corpuscle"
+cd "$BOUCHET_PROJECT/siphonophore_sample_corpuscle"
+cp "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" .
+#   edit:  input_pdfs: ../siphonophores_sample/library
+export CORPUS_CONFIG="$BOUCHET_PROJECT/siphonophore_sample_corpuscle/config.yaml"
 
-# Stage 1 (CPU, day partition)
-sbatch --job-name=corpus-sample-stage1 \
-    --export=ALL,INPUT_DIR=$SAMPLE_IN,OUTPUT_DIR=$SAMPLE_OUT \
-    slurm/batch_process_corpus.sh
+# 3. Run the phases. The simplest path is the orchestrator, which inherits
+#    $CORPUS_CONFIG via --export=ALL and runs the whole chain:
+bash slurm/batch_pipeline.sh
 
-# Pass 3b + 3c (GPU, ~30 min for 30 papers)
-sbatch --job-name=corpus-sample-pass3b \
-    --export=ALL,INPUT_DIR=$SAMPLE_IN,OUTPUT_DIR=$SAMPLE_OUT \
-    slurm/batch_pass3b.sh
-
-# Embeddings (GPU, <5 min for 30 papers)
-sbatch --job-name=corpus-sample-embed \
-    --export=ALL,OUTPUT_DIR=$SAMPLE_OUT \
-    slurm/batch_embed.sh
+#    …or submit phases by hand (each reads $CORPUS_CONFIG):
+# sbatch slurm/batch_process_corpus.sh     # extract (CPU, day)
+# sbatch slurm/batch_pass3b.sh             # vision  (GPU, gpu_h200)
+# sbatch slurm/batch_embed.sh              # embed   (GPU)
+# sbatch slurm/batch_finalize.sh           # post + bundle (CPU)
 ```
 
-Inspect `$BOUCHET_PROJECT/output_sample/documents/<HASH>/summary.json` and `figures_report.html` for a handful of papers. Confirm:
+Inspect `$BOUCHET_PROJECT/siphonophore_sample_corpuscle/documents/<HASH>/summary.json` and `figures_report.html` for a handful of papers. Confirm:
 
 - Grobid metadata populated (`metadata.json`)
 - Figures extracted + captioned, panels listed in `figures.json`
@@ -175,7 +248,7 @@ Only then submit the three production jobs against the full input.
 
 ## Production run
 
-The pipeline orchestrator (`slurm/batch_pipeline.sh`) handles Grobid startup, Stage 1 job-array submission, Grobid cleanup, and Pass 3b + Embed chaining automatically.
+The pipeline orchestrator (`slurm/batch_pipeline.sh`) handles Grobid startup, extract job-array submission, Grobid cleanup, and vision + embed + finalize chaining automatically — every job runs `corpus run --only <phase>` against `$CORPUS_CONFIG`.
 
 The orchestrator parallelizes both Stage 1 (CPU) and Pass 3b (GPU)
 independently. Stage 1 dominates wallclock for typical corpora; Pass 3b
@@ -204,94 +277,95 @@ NUM_BATCHES=8 NUM_PASS3B_BATCHES=4 bash slurm/batch_pipeline.sh
 ```
 
 The orchestrator:
-1. Starts Grobid as a SLURM job, waits for it to be alive
-2. Submits Stage 1 as a job array (`--array=0-N`), each task processing a deterministic slice of the sorted hash list
-3. Schedules Grobid cleanup after Stage 1 completes (runs regardless of success/failure)
-4. Queues Pass 3b (GPU array) and Embed (GPU) with `afterok` dependency on the full Stage 1 array
+1. Starts Grobid as a SLURM job, waits for it to be alive, exports `$GROBID_URL` for the extract job
+2. Submits **extract** (`batch_process_corpus.sh`) as a job array (`--array=0-N`), each task processing a deterministic slice of the sorted hash list
+3. Schedules Grobid cleanup after extract completes (runs regardless of success/failure)
+4. Queues **vision** (`batch_pass3b.sh`, GPU array) and **embed** (`batch_embed.sh`, GPU) with `afterok` dependency on the full extract array
+5. Queues **finalize** (`batch_finalize.sh` — `corpus run --only post` then `--only bundle`) with `afterok` dependency on embed
 
-For manual submission without the orchestrator:
+So the orchestrator now runs the whole build, including the cross-paper DBs and served-bundle distill, hands-off. Every job invokes `corpus -c "$CORPUS_CONFIG" run --only <phase>`.
+
+For manual submission without the orchestrator (each phase reads `$CORPUS_CONFIG`; resume is implicit):
 
 ```bash
-sbatch --array=0-7 slurm/batch_process_corpus.sh
+export GROBID_URL=http://<grobid_node>:8070      # extract needs Grobid
+sbatch --array=0-7 slurm/batch_process_corpus.sh # extract
 # After all array tasks complete:
-sbatch --array=0-3 slurm/batch_pass3b.sh   # parallel; or omit --array for single-task
-sbatch slurm/batch_embed.sh
+sbatch --array=0-3 slurm/batch_pass3b.sh         # vision; or omit --array for single-task
+sbatch slurm/batch_embed.sh                      # embed
+sbatch slurm/batch_finalize.sh                   # post + bundle → _serve/
 ```
 
-`--resume` in every script means restarts are cheap — re-queuing picks up where the previous run left off. Without `NUM_BATCHES` / `NUM_PASS3B_BATCHES` (or set to 1), the corresponding stage runs as a single job, which is usually right for small corpora.
+Resume is implicit in `corpus run`, so restarts are cheap — re-queuing a phase re-processes only papers whose inputs changed. Without `NUM_BATCHES` / `NUM_PASS3B_BATCHES` (or set to 1), the corresponding phase runs as a single job, which is usually right for small corpora.
 
-## Post-pipeline cross-paper databases
+## Post-pipeline cross-paper databases + served bundle
 
-The SLURM array produces per-paper artifacts under `$OUTPUT_DIR/documents/<HASH>/`. Four cross-paper steps then run as single-pass post-processing — they are required inputs to `package_for_serve.py`, which **silently skips missing SQLites** (see [package_for_serve.py:432](../package_for_serve.py#L432)) and produces an incomplete bundle. Always run these before packaging or uploading to S3.
+The extract/vision/embed phases produce per-paper artifacts under
+`<output_dir>/documents/<HASH>/`. The **post** phase then runs the four
+cross-paper builds in dependency order, and the **bundle** phase distills
+the served bundle. Both are wrapped by `slurm/batch_finalize.sh`, which the
+orchestrator chains automatically after embed — so normally you do nothing
+here. The four builds (no longer separate top-level scripts; #138 folds
+them into `corpus run --only post`) are:
+
+1. **biblio authority** — deduplicated works + citation graph (`bib.authority`)
+2. **taxon mentions** — cross-paper taxon-mention index (`pipeline.taxon_mentions`)
+3. **in-text citations** — TEI body → `intext_citations.json` per paper (`pipeline.intext_citations`)
+4. **reconcile** — merge ghost cited-references onto corpus papers (`bib.reconcile`)
+
+To run the tail by hand (e.g. after fixing a build issue):
 
 ```bash
-cd "$BOUCHET_PROJECT/corpus"
-conda activate corpus
+export CORPUS_CONFIG="$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml"
 
-# 1. Bibliographic authority (deduplicated works + citation graph).
-#    Default enables BHL enrichment for pre-1960 refs without DOIs —
-#    rate-limited at ~1 req/s, so this can take many hours on the
-#    week partition. Set BHL_ENRICH=0 for a fast (~10 min) build
-#    without BHL coverage.
-export BHL_API_KEY=<your-key>           # free at biodiversitylibrary.org/account
-sbatch slurm/batch_biblio.sh
-# BHL_ENRICH=0 sbatch slurm/batch_biblio.sh
+# Cross-paper DBs only. ENRICH_BHL=1 adds Biodiversity Heritage Library
+# coverage for pre-DOI refs (slow, rate-limited ~1 req/s — many hours on
+# the week partition); omit for a fast build without BHL.
+sbatch slurm/batch_finalize.sh
+# ENRICH_BHL=1 sbatch slurm/batch_finalize.sh
 
-# 2. Cross-paper taxon mentions index. Single-pass, quick — run on
-#    a login or interactive node, no SLURM wrapper needed.
-python build_taxon_mentions.py "$OUTPUT_DIR"
-
-# 3. In-text citation graph. Walks each paper's TEI body, joins
-#    <ref type="bibr"> elements to chunk offsets, and writes
-#    intext_citations.json into each documents/<HASH>/. Fast.
-python backfill_intext_citations.py "$OUTPUT_DIR"
-
-# 4. Reconcile ghost cited-references onto corpus papers. Merges
-#    references parsed by Grobid that point at corpus papers but
-#    weren't matched by the initial authority build.
-python reconcile_corpus_to_biblio.py "$OUTPUT_DIR"
+# Cross-paper DBs but skip the bundle distill:
+# SKIP_BUNDLE=1 sbatch slurm/batch_finalize.sh
 ```
 
-Or chain all four (after the BHL-enriched SLURM step finishes) with:
+`batch_finalize.sh` runs `corpus run --only post` then `corpus run --only
+bundle`. The post phase honors `--force-rebuild*` only when you ask; a plain
+re-run is idempotent. Confirm the cross-paper SQLites landed:
 
 ```bash
-python update_corpus.py "$INPUT_DIR" "$OUTPUT_DIR" --skip-pipeline --resume
+ls -la "$BOUCHET_PROJECT/siphonophore_corpuscle"/{taxonomy,biblio_authority,taxon_mentions}.sqlite
 ```
 
-`--skip-pipeline` runs only the post-pipeline scripts (steps 1-4), assuming Stages 1 + 2 already produced the per-paper artifacts. `--from build_taxa` is the equivalent if you need to rerun starting from a specific step.
-
-Confirm the SQLites landed before packaging:
+The bundle phase distills into `<output_dir>/_serve/` — for the production
+corpuscle that's `$BOUCHET_PROJECT/siphonophore_corpuscle/_serve/`. This
+replaces the old standalone `package_for_serve.py` / `SERVE_BUNDLE_DIR`
+step: `_serve/` **is** the deployable artifact (path-scrubbed + audited +
+manifested). Re-distill any time with:
 
 ```bash
-ls -la "$OUTPUT_DIR"/{taxonomy,biblio_authority,taxon_mentions}.sqlite
+corpus -c "$CORPUS_CONFIG" run --only bundle
+cat "$BOUCHET_PROJECT/siphonophore_corpuscle/_serve/bundle_manifest.json"
 ```
 
-Then package the served bundle (path scrub + audit + manifest):
-
-```bash
-python package_for_serve.py \
-    "$OUTPUT_DIR" "$BOUCHET_PROJECT/serve_bundle" \
-    --version v0.x.0
-cat "$BOUCHET_PROJECT/serve_bundle/bundle_manifest.json"
-```
-
-The bundle is what gets uploaded to S3 and consumed by the EC2 deploy — see [DEPLOY.md](DEPLOY.md) §6.
+`_serve/` is what gets uploaded to S3 and consumed by the EC2 deploy — see [DEPLOY.md](DEPLOY.md) §6.
 
 ## Partition reference (from dev_docs/PLAN.md §7)
 
-| Stage | Script | Partition | GPU? | Walltime |
+| Phase (`--only`) | Script | Partition | GPU? | Walltime |
 |---|---|---|---|---|
-| Stage 1 (OCR + docling + Grobid + Pass 2.5) | `slurm/batch_process_corpus.sh` | `day` | no | 24 h |
-| Pass 3b + 3c (Qwen2.5-VL-7B) | `slurm/batch_pass3b.sh` | `gpu_h200` | 1 | 24 h |
-| Embeddings (BGE-M3) | `slurm/batch_embed.sh` | `gpu` | 1 | 4 h |
+| `extract` (OCR + docling + Grobid + Pass 2.5) | `slurm/batch_process_corpus.sh` | `day` | no | 24 h |
+| `vision` (Pass 3b + 3c, Qwen2.5-VL-7B) | `slurm/batch_pass3b.sh` | `gpu_h200` | 1 | 24 h |
+| `embed` (BGE-M3) | `slurm/batch_embed.sh` | `gpu` | 1 | 4 h |
+| `post` + `bundle` (cross-paper DBs + served bundle) | `slurm/batch_finalize.sh` | `day` | no | 12 h |
 
-Adjust walltimes if the corpus grows beyond ~2000 papers.
+Each script runs `corpus -c "$CORPUS_CONFIG" run --only <phase>`. Adjust walltimes if the corpus grows beyond ~2000 papers.
 
 ## Common pitfalls
 
 - **Login nodes can't download models.** HF and other downloads must run on a compute node via `salloc`. Trying to pre-cache from a login node will hit outbound-firewall blocks.
 - **Stale `HF_HOME`.** If a job re-downloads a model, `HF_HOME` isn't being honored — check that the export in the SLURM script points to a path you actually populated.
-- **Grobid URL.** SLURM compute nodes can't talk to your laptop's `localhost:8070` — `GROBID_URL` must resolve to a host visible from the job's node. If the Grobid node goes down mid-run, subsequent papers get placeholder metadata; `--resume` won't retry them without `--no-resume` or manually deleting `metadata.json`.
-- **LFS on stage 1.** If stage 1 can't see the full PDFs (only LFS pointers), re-run `git lfs pull` in `$BOUCHET_PROJECT/siphonophores`.
-- **GPU partition trap for Pass 3b.** `rtx_5000_ada` nodes on the `gpu` partition carry an older NVIDIA driver (`nvidia-smi` reports CUDA 12.8 but torch 2.9.0+cu128 rejects it as "too old") and silently fall back to CPU, where Qwen2.5-VL-7B is unusable. Always submit Pass 3b to `gpu_h200 --gpus=h200:1`. A pre-flight `python -c "import torch; assert torch.cuda.is_available()"` in `slurm/batch_pass3b.sh` aborts the job early if this is ever regressed.
+- **Grobid URL.** SLURM compute nodes can't talk to your laptop's `localhost:8070` — `$GROBID_URL` (which overrides the config's `grobid.url`) must resolve to a host visible from the job's node. If the Grobid node goes down mid-run, subsequent papers get placeholder metadata; a re-run's implicit resume won't retry them unless their inputs changed — force it with `corpus run --only extract --re-process-flagged <gate>` or by deleting the affected `metadata.json`.
+- **Config not found / wrong corpuscle.** Every phase script reads `$CORPUS_CONFIG`. If a job dies with "no config.yaml" or builds the wrong tree, confirm `$CORPUS_CONFIG` points at the intended `config.yaml` (default is the production corpuscle; a leftover `export CORPUS_CONFIG=…sample…` from a smoke test will silently redirect a production submit).
+- **LFS on extract.** If extract can't see the full PDFs (only LFS pointers), re-run `git lfs pull` in `$BOUCHET_PROJECT/siphonophores`.
+- **GPU partition trap for the vision phase.** `rtx_5000_ada` nodes on the `gpu` partition carry an older NVIDIA driver (`nvidia-smi` reports CUDA 12.8 but torch 2.9.0+cu128 rejects it as "too old") and silently fall back to CPU, where Qwen2.5-VL-7B is unusable. Always submit the vision phase to `gpu_h200 --gpus=h200:1`. A pre-flight `python -c "import torch; assert torch.cuda.is_available()"` in `slurm/batch_pass3b.sh` aborts the job early if this is ever regressed.
 - **lmod module cache flakiness.** `module load CUDA/12.6.0` occasionally errors with `CUDA/12.6.0.lua: Empty or non-existent file` even though `module spider CUDA` lists it. `slurm/batch_pass3b.sh` now skips the explicit CUDA module entirely — torch 2.9.0+cu128 ships bundled CUDA userspace libs in `site-packages/nvidia/` and works without it on gpu_h200. If another script hits this, retry with `module --ignore-cache load …`.

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -423,6 +423,31 @@ cat "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/_serve/bundle_manifest.js
 
 `_serve/` is what gets uploaded to S3 and consumed by the EC2 deploy — see [DEPLOY.md](DEPLOY.md) §6.
 
+## Acceptance testing a completed build
+
+After `batch_finalize.sh` completes, verify the corpuscle on an **interactive compute
+node** (not the login node — the MCP server loads the ~600 MB BGE-M3 embedder when
+the first semantic-search tool is called, which requires more memory than the shared
+login node allows):
+
+```bash
+salloc -p devel -t 2:00:00 --mem=32G
+module load miniconda
+conda activate corpus
+
+# 1. Programmatic smoke test (corpus-agnostic, any corpuscle)
+python "$BOUCHET_PROJECT/corpus/tools/smoke_test_sse.py" \
+    "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD" \
+    --server-startup-timeout 120
+
+# 2. Manual acceptance prompts (siphonophore-specific — see note)
+#    Connect Claude to the running MCP server and paste each prompt from:
+#    dev_docs/ACCEPTANCE_PROMPTS.md
+```
+
+> **Note:** `ACCEPTANCE_PROMPTS.md` is a siphonophore-specific example.
+> For a different corpus, copy it and substitute taxon/author names.
+
 ## Partition reference (from dev_docs/PLAN.md §7)
 
 | Phase (`--only`) | Script | Partition | GPU? | Walltime |

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -122,8 +122,13 @@ phases without writing artifacts:
 
 ```bash
 corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" check
-corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" run --dry-run
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" run --dry-run --skip-checks
 ```
+
+On the login node `corpus check` will always warn about GPU and Grobid —
+both are expected (GPU runs on compute nodes, Grobid is started automatically
+by `batch_pipeline.sh`). All other checks should be green. `--skip-checks`
+is needed for `--dry-run` on the login node for the same reason.
 
 `$CORPUS_CONFIG` already defaults to this path in `bouchet_paths.sh` (after
 updating it), so the phase scripts find it with no extra flags. To build a
@@ -142,6 +147,19 @@ have internet) before the first pipeline submission:
 conda activate corpus
 corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" taxonomy ingest --source worms --root-id 1371
 # → writes corpuscles/siphonophore_YYYYMMDD/taxonomy.sqlite (~700 KB, takes ~1–2 min)
+```
+
+**If `taxonomy.dwca.zip` is already committed to the siphonophores repo** (the
+normal case after the first build), skip the WoRMS step and ingest directly
+from the zip — works on any node, takes under a second:
+
+```bash
+conda activate corpus
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" \
+    taxonomy ingest --source dwca \
+    --input "$BOUCHET_PROJECT/siphonophores/taxonomy.dwca.zip" \
+    --root-id 1371
+# → writes corpuscles/siphonophore_YYYYMMDD/taxonomy.sqlite in ~1 s
 ```
 
 Then export it as a portable DwC-A zip and commit it to the siphonophores repo.

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -118,7 +118,43 @@ corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" run --dry-run
 phase scripts find it with no extra flags. To build a *different* corpuscle,
 export `CORPUS_CONFIG=/path/to/other/config.yaml` before submitting.
 
-### 4. Pre-download HuggingFace models
+### 4. Pre-build the taxonomy
+
+**Do this before submitting any batch jobs.** Batch compute nodes on Bouchet
+do not have outbound internet access, so `source: worms` will silently fail
+during `corpus run --only extract` — taxon extraction is skipped and
+`taxonomy.sqlite` is never written. Build it on the login node (which does
+have internet) before the first pipeline submission:
+
+```bash
+conda activate corpus
+corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy ingest --source worms
+# → writes siphonophore_corpuscle/taxonomy.sqlite (~700 KB, takes ~1–2 min)
+```
+
+Then export it as a portable DwC-A zip and update `config.yaml` to use the
+local file. This makes future runs — including on nodes without internet —
+ingest from the zip in seconds instead of walking the WoRMS REST API:
+
+```bash
+corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy export \
+    -o "$BOUCHET_PROJECT/siphonophores/taxonomy.dwca.zip"
+```
+
+Update `config.yaml`:
+
+```yaml
+taxonomy:
+  source: dwca
+  path: ../siphonophores/taxonomy.dwca.zip   # local; works on isolated compute nodes
+  root_id: 1371
+```
+
+Commit `taxonomy.dwca.zip` to the siphonophores repo so the taxonomy is
+version-controlled alongside the PDFs and bib file. If WoRMS upstream changes
+significantly, regenerate with `--source worms` and re-export.
+
+### 4b. Pre-download HuggingFace models
 
 Do this once on an interactive node (login nodes usually block outbound internet; request a compute node with `salloc -p interactive -t 0:30:00`):
 
@@ -270,10 +306,11 @@ NUM_BATCHES=8 bash slurm/batch_pipeline.sh
 NUM_BATCHES=4 BATCH_SIZE=512 bash slurm/batch_pipeline.sh
 
 # Parallelize Pass 3b too — useful when figure-heavy corpora make the
-# vision pass the long pole. NUM_PASS3B_BATCHES = ceil(total_papers /
-# PASS3B_BATCH_SIZE). gpu_h200 partition has limited slots, so check
-# `sinfo -p gpu_h200` before fanning out aggressively.
-NUM_BATCHES=8 NUM_PASS3B_BATCHES=4 bash slurm/batch_pipeline.sh
+# vision pass the long pole. NUM_PASS3B_BATCHES should equal NUM_BATCHES
+# so every paper is covered (default is now $NUM_BATCHES when unset).
+# gpu_h200 partition has limited slots, so check `sinfo -p gpu_h200`
+# before fanning out aggressively.
+NUM_BATCHES=8 NUM_PASS3B_BATCHES=8 bash slurm/batch_pipeline.sh
 ```
 
 The orchestrator:

--- a/dev_docs/BOUCHET.md
+++ b/dev_docs/BOUCHET.md
@@ -27,21 +27,27 @@ git lfs pull                              # ~2000 PDFs, several GB
 Resulting layout (all under `$BOUCHET_PROJECT`):
 
 ```
-corpus/                       ← this repo (the `corpus` CLI)
-siphonophores/                ← input PDF tree + siphonophores.bib + lexicon.yaml
-siphonophore_corpuscle/       ← the corpuscle: config.yaml + build artifacts
-  config.yaml                 ← authored in step 3 (the source of truth)
-  documents/<HASH>/…          ← per-paper artifacts (created by extract)
-  *.sqlite, vector_db/        ← cross-paper DBs + LanceDB (created by embed/post)
-  _serve/                     ← distilled served bundle (created by bundle)
-cache/huggingface/            ← model cache (see below)
+corpus/                          ← this repo (the `corpus` CLI)
+siphonophores/                   ← input PDF tree + siphonophores.bib + lexicon.yaml
+corpuscles/                      ← all siphonophore corpuscle builds
+  siphonophore_YYYYMMDD/         ← one directory per production build (date = build date)
+    config.yaml                  ← authored in step 3 (the source of truth)
+    documents/<HASH>/…           ← per-paper artifacts (created by extract)
+    *.sqlite, vector_db/         ← cross-paper DBs + LanceDB (created by embed/post)
+    _serve/                      ← distilled served bundle (created by bundle)
+  siphonophore_sample_YYYYMMDD/  ← sample/smoke-test builds (same structure)
+cache/huggingface/               ← model cache (see below)
 ```
+
+When starting a new build, create `corpuscles/siphonophore_YYYYMMDD/`, scaffold a
+`config.yaml` there (step 3), and update the `CORPUS_CONFIG` default in
+`slurm/bouchet_paths.sh` to point at it (one-line change).
 
 As of #138 the SLURM phase scripts drive the **same `corpus run` CLI**
 users run, one phase per job. All per-corpuscle inputs (PDF dir, BibTeX,
-lexicon, taxonomy source, Grobid) live in `siphonophore_corpuscle/config.yaml`
+lexicon, taxonomy source, Grobid) live in the corpuscle's `config.yaml`
 — **not** as CLI flags or env vars. The scripts reference it through
-`$CORPUS_CONFIG` (default `$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml`,
+`$CORPUS_CONFIG` (default `$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml`,
 set in [slurm/bouchet_paths.sh](../slurm/bouchet_paths.sh)).
 
 ### 2. Conda environment
@@ -72,29 +78,34 @@ per-corpuscle input from it. Scaffold it once, then edit:
 
 ```bash
 conda activate corpus
-mkdir -p "$BOUCHET_PROJECT/siphonophore_corpuscle"
-cd "$BOUCHET_PROJECT/siphonophore_corpuscle"
+# Replace YYYYMMDD with today's date, e.g. 20260603
+mkdir -p "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD"
+cd "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD"
 corpus init                              # drops a commented config.yaml here
 ```
 
+Update the `CORPUS_CONFIG` default in `slurm/bouchet_paths.sh` to point at
+the new directory (one-line change).
+
 Edit `config.yaml` so it points at the siphonophores repo. Paths resolve
-**relative to the config file's directory** (here, `siphonophore_corpuscle/`),
-so the `../siphonophores/...` paths below work regardless of
+**relative to the config file's directory** (here, `corpuscles/siphonophore_YYYYMMDD/`),
+so the `../../siphonophores/...` paths below work regardless of
 `$BOUCHET_PROJECT` (YAML has no env-var expansion — keep them relative or
 write absolute literals):
 
 ```yaml
-# $BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml
-input_pdfs: ../siphonophores/library          # the PDF tree (was $INPUT_DIR)
+# $BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml
+input_pdfs: ../../siphonophores/library       # the PDF tree
 output_dir: .                                 # artifacts land here in the
-                                              #   corpuscle dir (= old $OUTPUT_DIR);
+                                              #   corpuscle dir;
                                               #   keeps resume pointed at any
                                               #   existing documents/<HASH>/ tree
-bib: ../siphonophores/siphonophores.bib       # was $BIB_FILE
-lexicon: ../siphonophores/lexicon.yaml        # was $LEXICON
+bib: ../../siphonophores/siphonophores.bib
+lexicon: ../../siphonophores/lexicon.yaml
 
 taxonomy:                                     # Siphonophorae, WoRMS AphiaID 1371
-  source: worms
+  source: dwca
+  path: ../../siphonophores/taxonomy.dwca.zip # pre-exported; see step 4
   root_id: 1371
 
 figures:
@@ -110,13 +121,14 @@ can run the build and the config parses; `corpus run --dry-run` plans the
 phases without writing artifacts:
 
 ```bash
-corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" check
-corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" run --dry-run
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" check
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" run --dry-run
 ```
 
-`$CORPUS_CONFIG` already defaults to this path in `bouchet_paths.sh`, so the
-phase scripts find it with no extra flags. To build a *different* corpuscle,
-export `CORPUS_CONFIG=/path/to/other/config.yaml` before submitting.
+`$CORPUS_CONFIG` already defaults to this path in `bouchet_paths.sh` (after
+updating it), so the phase scripts find it with no extra flags. To build a
+*different* corpuscle, export `CORPUS_CONFIG=/path/to/other/config.yaml`
+before submitting.
 
 ### 4. Pre-build the taxonomy
 
@@ -128,25 +140,25 @@ have internet) before the first pipeline submission:
 
 ```bash
 conda activate corpus
-corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy ingest --source worms --root-id 1371
-# → writes siphonophore_corpuscle/taxonomy.sqlite (~700 KB, takes ~1–2 min)
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" taxonomy ingest --source worms --root-id 1371
+# → writes corpuscles/siphonophore_YYYYMMDD/taxonomy.sqlite (~700 KB, takes ~1–2 min)
 ```
 
-Then export it as a portable DwC-A zip and update `config.yaml` to use the
-local file. This makes future runs — including on nodes without internet —
-ingest from the zip in seconds instead of walking the WoRMS REST API:
+Then export it as a portable DwC-A zip and commit it to the siphonophores repo.
+This makes every future build ingest from the zip in seconds instead of
+re-walking the WoRMS REST API, and works on isolated compute nodes:
 
 ```bash
-corpus -c "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" taxonomy export \
+corpus -c "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" taxonomy export \
     -o "$BOUCHET_PROJECT/siphonophores/taxonomy.dwca.zip"
 ```
 
-Update `config.yaml`:
+Update `config.yaml` (the corpuscle dir is two levels below `siphonophores/`):
 
 ```yaml
 taxonomy:
   source: dwca
-  path: ../siphonophores/taxonomy.dwca.zip   # local; works on isolated compute nodes
+  path: ../../siphonophores/taxonomy.dwca.zip  # local; works on isolated compute nodes
   root_id: 1371
 ```
 
@@ -259,13 +271,14 @@ selected by exporting `CORPUS_CONFIG`:
 mkdir -p "$BOUCHET_PROJECT/siphonophores_sample/library"
 # …copy ~30 PDFs into siphonophores_sample/library/
 
-# 2. A sample corpuscle config. Copy the real one and repoint input_pdfs;
-#    output_dir: . keeps the sample's artifacts out of the production tree.
-mkdir -p "$BOUCHET_PROJECT/siphonophore_sample_corpuscle"
-cd "$BOUCHET_PROJECT/siphonophore_sample_corpuscle"
-cp "$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml" .
-#   edit:  input_pdfs: ../siphonophores_sample/library
-export CORPUS_CONFIG="$BOUCHET_PROJECT/siphonophore_sample_corpuscle/config.yaml"
+# 2. A sample corpuscle. Use today's date, e.g. 20260603.
+mkdir -p "$BOUCHET_PROJECT/corpuscles/siphonophore_sample_YYYYMMDD"
+cd "$BOUCHET_PROJECT/corpuscles/siphonophore_sample_YYYYMMDD"
+# Copy the production config and repoint input_pdfs; output_dir: . keeps
+# the sample's artifacts out of the production tree.
+cp "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml" .
+#   edit:  input_pdfs: ../../siphonophores_sample/library
+export CORPUS_CONFIG="$BOUCHET_PROJECT/corpuscles/siphonophore_sample_YYYYMMDD/config.yaml"
 
 # 3. Run the phases. The simplest path is the orchestrator, which inherits
 #    $CORPUS_CONFIG via --export=ALL and runs the whole chain:
@@ -278,7 +291,7 @@ bash slurm/batch_pipeline.sh
 # sbatch slurm/batch_finalize.sh           # post + bundle (CPU)
 ```
 
-Inspect `$BOUCHET_PROJECT/siphonophore_sample_corpuscle/documents/<HASH>/summary.json` and `figures_report.html` for a handful of papers. Confirm:
+Inspect `$BOUCHET_PROJECT/corpuscles/siphonophore_sample_YYYYMMDD/documents/<HASH>/summary.json` and `figures_report.html` for a handful of papers. Confirm:
 
 - Grobid metadata populated (`metadata.json`)
 - Figures extracted + captioned, panels listed in `figures.json`
@@ -359,7 +372,7 @@ them into `corpus run --only post`) are:
 To run the tail by hand (e.g. after fixing a build issue):
 
 ```bash
-export CORPUS_CONFIG="$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml"
+export CORPUS_CONFIG="$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/config.yaml"
 
 # Cross-paper DBs only. ENRICH_BHL=1 adds Biodiversity Heritage Library
 # coverage for pre-DOI refs (slow, rate-limited ~1 req/s — many hours on
@@ -376,18 +389,18 @@ bundle`. The post phase honors `--force-rebuild*` only when you ask; a plain
 re-run is idempotent. Confirm the cross-paper SQLites landed:
 
 ```bash
-ls -la "$BOUCHET_PROJECT/siphonophore_corpuscle"/{taxonomy,biblio_authority,taxon_mentions}.sqlite
+ls -la "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD"/{taxonomy,biblio_authority,taxon_mentions}.sqlite
 ```
 
 The bundle phase distills into `<output_dir>/_serve/` — for the production
-corpuscle that's `$BOUCHET_PROJECT/siphonophore_corpuscle/_serve/`. This
+corpuscle that's `$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/_serve/`. This
 replaces the old standalone `package_for_serve.py` / `SERVE_BUNDLE_DIR`
 step: `_serve/` **is** the deployable artifact (path-scrubbed + audited +
 manifested). Re-distill any time with:
 
 ```bash
 corpus -c "$CORPUS_CONFIG" run --only bundle
-cat "$BOUCHET_PROJECT/siphonophore_corpuscle/_serve/bundle_manifest.json"
+cat "$BOUCHET_PROJECT/corpuscles/siphonophore_YYYYMMDD/_serve/bundle_manifest.json"
 ```
 
 `_serve/` is what gets uploaded to S3 and consumed by the EC2 deploy — see [DEPLOY.md](DEPLOY.md) §6.

--- a/dev_docs/PLAN.md
+++ b/dev_docs/PLAN.md
@@ -57,6 +57,32 @@ full v0.5 plan archived in the
 Open work is tracked in
 [GitHub issues](https://github.com/caseywdunn/corpus/issues).
 
+## 0. Open branches / pre-merge gates
+
+### `issue-corpus-run-hpc-1-engine` → dev
+
+Branch is complete (12 commits ahead of dev) but **must not be merged until the
+acceptance tests pass on a compute node**:
+
+```bash
+salloc -p devel -t 2:00:00 --mem=32G
+module load miniconda && conda activate corpus
+cd $BOUCHET_PROJECT/corpus
+
+# Programmatic smoke test (all layers, including semantic search)
+python tools/smoke_test_sse.py \
+    $BOUCHET_PROJECT/corpuscles/siphonophore_20260603 \
+    --server-startup-timeout 120
+
+# Manual acceptance prompts — connect Claude to the running MCP server
+# and work through dev_docs/ACCEPTANCE_PROMPTS.md
+```
+
+Both must pass before opening the PR to dev.  The smoke test exits 0 on
+success.  For the acceptance prompts, confirm at minimum: corpus summary,
+one taxon dossier, one semantic search result, one bibliography lookup,
+and the lexicon matrix.
+
 ## 1. v0.6 punch list
 
 ### Group A — MCP tool-surface API-freeze pass

--- a/mcpsrv/bundle.py
+++ b/mcpsrv/bundle.py
@@ -75,7 +75,21 @@ logger = logging.getLogger("package_for_serve")
 # /workspace, /scratch, /data, /export, etc. Earlier revisions allow-
 # listed a short set of roots — that left /private, /tmp, /Volumes
 # leaking through the audit.
-_ABS_PATH_RE = re.compile(r'^/[A-Za-z0-9_.+-]+/')
+#
+# Two false-positive classes excluded via regex + caller guard:
+#   1. PDF glyph codes (/G03/G38/, /G3/G71/, /c81f5/c8167/...): first
+#      component is one letter + one or more hex digits — excluded by
+#      (?![A-Za-z][0-9A-Fa-f]+/). Real path roots (nfs, home, tmp, var,
+#      …) always contain at least one non-hex character after the first
+#      letter (e.g. 'n'+'f's', not all-hex), so the lookahead never fires
+#      on them. Purely-hex names like /cafe/ would be silently skipped —
+#      acceptable on HPC systems where roots are human-readable words.
+#   2. DOI/URL fragments (/10.1016/j.ocemod.2012.10.007) and glyph+text
+#      strings (/journal/rsos R. Soc., /g20/g17 This is...): DOIs start
+#      with a digit, excluded by requiring [A-Za-z] as the first char.
+#      Strings with spaces are excluded by the ``' ' not in s`` guard in
+#      the caller (real filesystem paths never contain spaces on HPC).
+_ABS_PATH_RE = re.compile(r'^/(?![A-Za-z][0-9A-Fa-f]+/)[A-Za-z][A-Za-z0-9_.+-]+/')
 
 # The per-paper whitelist.  Top-level files only — figures/ is handled
 # separately as a directory copy.
@@ -541,7 +555,7 @@ def _audit_no_absolute_paths(serve_dir: Path) -> List[Tuple[str, str]]:
         except Exception:
             continue
         for s in _walk_strings(data):
-            if _ABS_PATH_RE.match(s):
+            if ' ' not in s and _ABS_PATH_RE.match(s):
                 offenders.append((str(jp.relative_to(serve_dir)), s[:120]))
                 break  # one offender per file is enough to flag it
     return offenders

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -421,6 +421,16 @@ def _cmd_run(args: argparse.Namespace) -> int:
         print_status(f"config not found: {config_path}", status="fail")
         return EXIT_CONFIG_ERROR
     cfg = _load_validated(config_path)
+    # $GROBID_URL overrides the configured Grobid address (#138). On HPC,
+    # Grobid runs on a dynamically-allocated compute node whose hostname
+    # isn't known until submit time, so the static config.yaml value can't
+    # name it; slurm/batch_pipeline.sh discovers the node and exports
+    # GROBID_URL. Matches the old `pipeline.main` default-from-$GROBID_URL
+    # behavior. Applied before the precondition ping and the argv build so
+    # both see the override.
+    grobid_url_env = os.environ.get("GROBID_URL")
+    if grobid_url_env:
+        cfg.grobid.url = grobid_url_env
     output_dir = _resolve_against(config_path, cfg.output_dir)
     # Single-phase HPC selector (#corpus-run-hpc): None = full run on one
     # node; extract/vision/embed/post run one orchestrator phase; bundle

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -994,7 +994,63 @@ def _cmd_check(args: argparse.Namespace) -> int:
             failures.append(f"input_pdfs path does not exist: {input_dir}")
             pstatus(f"input_pdfs: {input_dir} not found", status="fail")
 
-    # 7. macOS Python arch — Rosetta'd Python on Apple Silicon traps the
+    # 7. Taxonomy source availability
+    if cfg.taxonomy.source is not None:
+        db_path = output_dir / "taxonomy.sqlite"
+        if cfg.taxonomy.source == "worms":
+            # WoRMS reaches out to the network. On an internet-connected node
+            # a first `corpus run` will build taxonomy.sqlite automatically.
+            # On HPC compute nodes (no outbound internet), the sqlite must be
+            # pre-built on a login node first — `corpus run --only extract`
+            # will fail loudly if it is absent.
+            if db_path.exists():
+                pstatus(
+                    f"Taxonomy: {db_path.name} present (WoRMS pre-built)",
+                    status="ok",
+                )
+            else:
+                pstatus(
+                    "Taxonomy: taxonomy.sqlite not yet built — WoRMS will be "
+                    "fetched on first run (requires internet; pre-build on a "
+                    "login node before submitting HPC array jobs)",
+                    status="warn",
+                )
+        else:  # dwca / dwc
+            tx_path = (
+                _resolve_against(config_path, cfg.taxonomy.path)
+                if cfg.taxonomy.path is not None else None
+            )
+            if tx_path is None:
+                failures.append(
+                    f"taxonomy.source={cfg.taxonomy.source!r} but "
+                    "taxonomy.path is not set in config."
+                )
+                pstatus(
+                    f"Taxonomy: source={cfg.taxonomy.source!r}, path not set",
+                    status="fail",
+                )
+            elif not tx_path.exists():
+                failures.append(
+                    f"taxonomy.source={cfg.taxonomy.source!r} but "
+                    f"taxonomy.path={tx_path} does not exist."
+                )
+                pstatus(f"Taxonomy: {tx_path} not found", status="fail")
+            elif db_path.exists():
+                pstatus(
+                    f"Taxonomy: {db_path.name} present "
+                    f"(source: {cfg.taxonomy.source})",
+                    status="ok",
+                )
+            else:
+                # Archive/dir is present but sqlite not yet built — the next
+                # full `corpus run` will build it via ingest_taxonomy.
+                pstatus(
+                    f"Taxonomy: {tx_path.name} found, "
+                    f"{db_path.name} not yet built (will be created on first run)",
+                    status="warn",
+                )
+
+    # 8. macOS Python arch — Rosetta'd Python on Apple Silicon traps the
     # env in the unsupported macOS x86_64 matrix (Apple dropped Intel-mac
     # torch wheels after 2.2, breaking docling + transformers ≥ 5). Hard
     # fail loud rather than letting `corpus run` discover it deep in a

--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -395,6 +395,16 @@ def _build_orchestrator_argv(
         sub_argv.append("--force-rebuild-biblio")
     if args.force_rebuild_taxon_mentions:
         sub_argv.append("--force-rebuild-taxon-mentions")
+    # HPC single-phase + array slicing (#corpus-run-hpc). `bundle` is a
+    # CLI-level phase (handled before the orchestrator is invoked), so
+    # it's never forwarded here.
+    only = getattr(args, "only", None)
+    if only is not None and only != "bundle":
+        sub_argv += ["--only", only]
+    if getattr(args, "batch_index", None) is not None:
+        sub_argv += ["--batch-index", str(args.batch_index)]
+    if getattr(args, "batch_size", None) is not None:
+        sub_argv += ["--batch-size", str(args.batch_size)]
     return sub_argv
 
 
@@ -411,29 +421,56 @@ def _cmd_run(args: argparse.Namespace) -> int:
         print_status(f"config not found: {config_path}", status="fail")
         return EXIT_CONFIG_ERROR
     cfg = _load_validated(config_path)
+    output_dir = _resolve_against(config_path, cfg.output_dir)
+    # Single-phase HPC selector (#corpus-run-hpc): None = full run on one
+    # node; extract/vision/embed/post run one orchestrator phase; bundle
+    # distills the served bundle only. Each maps to its own SLURM job.
+    only = getattr(args, "only", None)
+    if (args.batch_index is None) != (args.batch_size is None):
+        print_status("--batch-index and --batch-size must be given together",
+                     status="fail")
+        return EXIT_CONFIG_ERROR
+    if args.batch_index is not None and only not in ("extract", "vision"):
+        print_status(
+            "--batch-index/--batch-size apply only to --only extract|vision",
+            status="fail")
+        return EXIT_CONFIG_ERROR
 
-    # Fail-fast preconditions: catch the two ergonomic cliffs that would
-    # otherwise burn hours of compute (Grobid unreachable → placeholder
-    # metadata across the whole bibliography pass; input_pdfs missing →
-    # silent zero-paper run). The vision/ANTHROPIC_API_KEY paths are
-    # warn-and-skip (#65) — graceful degradation, not a fail-fast case.
-    if not args.skip_checks:
-        rc = _run_preconditions(cfg, config_path, args)
+    # --only bundle: (re)distill the served bundle from existing
+    # output_dir artifacts. No preconditions / prune / pipeline.
+    if only == "bundle":
+        if args.dry_run:
+            print_status(
+                f"dry-run: would distill served bundle into {output_dir / '_serve'}",
+                status="info")
+            return EXIT_OK
+        if args.no_bundle:
+            print_status("--only bundle with --no-bundle is a no-op", status="warn")
+            return EXIT_OK
+        return _distill_bundle(output_dir)
+
+    # Preconditions + orphan prune + flag-invalidation are extract-phase
+    # concerns — skip them for the GPU (vision/embed) and post phases,
+    # which scan no input and need no Grobid.
+    if only in (None, "extract"):
+        # Fail-fast preconditions: catch the two ergonomic cliffs that
+        # would otherwise burn hours (Grobid unreachable → placeholder
+        # metadata; input_pdfs missing → silent zero-paper run). The
+        # vision/ANTHROPIC_API_KEY paths are warn-and-skip (#65).
+        if not args.skip_checks:
+            rc = _run_preconditions(cfg, config_path, args)
+            if rc != EXIT_OK:
+                return rc
+        # #66: orphan cleanup before extract so later stages don't consume
+        # orphan hashes. Default prune; --no-prune = audit; --force-prune
+        # bypasses the safety rail.
+        rc = _prune_orphans(cfg, config_path, args)
         if rc != EXIT_OK:
             return rc
-
-    # #66: orphan cleanup runs *before* the extract step so subsequent
-    # stages don't consume the orphan hashes. Default = prune; --no-prune
-    # = read-only audit only; --force-prune bypasses the safety rail.
-    rc = _prune_orphans(cfg, config_path, args)
-    if rc != EXIT_OK:
-        return rc
-
-    # #54: --re-process-flagged invalidates pipeline_state.json for every
-    # paper carrying the named quality_flag, so the per-stage resume
-    # logic re-extracts them on the upcoming run.
-    if args.re_process_flagged:
-        _invalidate_flagged(cfg, config_path, args.re_process_flagged)
+        # #54: --re-process-flagged invalidates pipeline_state.json for
+        # papers carrying the named quality_flag so resume re-extracts them.
+        if args.re_process_flagged:
+            _invalidate_flagged(cfg, config_path, args.re_process_flagged)
 
     sub_argv = _build_orchestrator_argv(cfg, config_path, args)
     cmd = [sys.executable, "-m", "pipeline.orchestrator", *sub_argv]
@@ -453,7 +490,6 @@ def _cmd_run(args: argparse.Namespace) -> int:
     # `Expected top-level file instructions.md missing from <output_dir>`.
     # We copy on mtime change, so re-runs are idempotent and edits
     # propagate.
-    output_dir = _resolve_against(config_path, cfg.output_dir)
     if not args.dry_run and config_path is not None:
         src_instructions = config_path.parent / "instructions.md"
         if src_instructions.exists():
@@ -466,33 +502,34 @@ def _cmd_run(args: argparse.Namespace) -> int:
             if needs_copy:
                 shutil.copy2(src_instructions, dst_instructions)
 
-    # #60 — bundle distillation in line. Produce a ready-to-ship served
-    # bundle alongside the build bundle unless --no-bundle. The served
-    # bundle lands at `<output_dir>/_serve/` and is the directory remote
-    # deploys (DEPLOY.md) ship to S3 / EC2.
-    if args.no_bundle:
-        print_status(
-            "skipping served-bundle distillation (--no-bundle)",
-            status="info",
-        )
-    elif args.dry_run:
-        print_status(
-            f"dry-run: would distill served bundle into {output_dir / '_serve'}",
-            status="info",
-        )
-    else:
-        rc = _distill_bundle(output_dir)
-        if rc != 0:
+    # #60 — bundle distillation in line, on a full run only. The served
+    # bundle lands at `<output_dir>/_serve/`. Sub-phases (extract / vision
+    # / embed / post) skip it — the HPC flow distills once via a final
+    # `--only bundle` job; `--only bundle` is handled at the top.
+    if only is None:
+        if args.no_bundle:
             print_status(
-                f"served-bundle distillation failed (exit {rc}); the build "
-                "bundle is intact but no served bundle was produced. Re-run "
-                "`python -m mcpsrv.bundle <output_dir> <serve_dir> "
-                "--version vX.Y.Z` to retry, or pass --no-bundle to skip.",
-                status="fail",
+                "skipping served-bundle distillation (--no-bundle)",
+                status="info",
             )
-            # Propagate: _serve/ is the deployable artifact (DEPLOY.md);
-            # a failed distill must not stamp the run as successful.
-            return rc
+        elif args.dry_run:
+            print_status(
+                f"dry-run: would distill served bundle into {output_dir / '_serve'}",
+                status="info",
+            )
+        else:
+            rc = _distill_bundle(output_dir)
+            if rc != 0:
+                print_status(
+                    f"served-bundle distillation failed (exit {rc}); the build "
+                    "bundle is intact but no served bundle was produced. Re-run "
+                    "`python -m mcpsrv.bundle <output_dir> <serve_dir> "
+                    "--version vX.Y.Z` to retry, or pass --no-bundle to skip.",
+                    status="fail",
+                )
+                # Propagate: _serve/ is the deployable artifact (DEPLOY.md);
+                # a failed distill must not stamp the run as successful.
+                return rc
 
     if args.dry_run:
         print_status(
@@ -500,6 +537,10 @@ def _cmd_run(args: argparse.Namespace) -> int:
             "`--dry-run` to execute the plan above.",
             status="ok",
         )
+    elif only not in (None, "post"):
+        # A sub-phase (extract / vision / embed) — its job is done; the
+        # run-log + report come from the full run or the post phase.
+        print_status(f"phase '{only}' complete.", status="ok")
     else:
         run_log = _write_run_log(output_dir, cfg=cfg, argv=sys.argv)
         if run_log is None:
@@ -1425,6 +1466,24 @@ def _build_parser() -> argparse.ArgumentParser:
     run_p.add_argument("--enrich-bhl", action="store_true",
                        help="Enrich pre-DOI references against the Biodiversity "
                        "Heritage Library (slow, rate-limited; #64)")
+    # HPC / job-array support: run one phase per SLURM job, on the right
+    # partition, and slice the per-paper stages into array tasks. Omit
+    # --only to run the whole pipeline on one node (the default).
+    run_p.add_argument(
+        "--only", choices=["extract", "vision", "embed", "post", "bundle"],
+        default=None,
+        help="Run only one phase (for HPC, where each maps to a separate "
+             "SLURM job/partition): extract (CPU), vision (GPU Pass 3b "
+             "refresh), embed (GPU), post (cross-paper DBs), bundle (served-"
+             "bundle distill). Omit to run the full pipeline on one node.")
+    run_p.add_argument(
+        "--batch-index", type=int, default=None,
+        help="0-based array-task index; with --batch-size, processes a "
+             "deterministic slice of the sorted hash list (SLURM job "
+             "arrays). Only with --only extract|vision.")
+    run_p.add_argument(
+        "--batch-size", type=int, default=None,
+        help="PDFs per array task (pairs with --batch-index).")
     run_p.set_defaults(func=_cmd_run)
 
     # --- debug-pdf ---

--- a/pipeline/orchestrator.py
+++ b/pipeline/orchestrator.py
@@ -233,6 +233,71 @@ def _batch_flags(args: argparse.Namespace) -> List[str]:
     return []
 
 
+def _check_taxonomy_available(
+    args: argparse.Namespace, selected: List[Step]
+) -> Optional[str]:
+    """Return an error string if taxonomy is configured but unavailable.
+
+    Two failure modes:
+
+    * ``ingest_taxonomy`` is *not* in the selected steps (e.g. ``--only
+      extract`` on an HPC compute node) but ``taxonomy.sqlite`` is absent
+      — the extract step will silently skip taxon annotation. Fail before
+      any work starts so the operator knows to pre-build the taxonomy on a
+      network-connected node first.
+
+    * Source is ``dwca`` or ``dwc`` and the local archive/directory path
+      does not exist — ``ingest_taxonomy`` would fail immediately; surface
+      this sooner with a more descriptive message.
+    """
+    if not args.taxonomy_source:
+        return None
+
+    step_names = {s.name for s in selected}
+
+    if "ingest_taxonomy" in step_names:
+        # ingest_taxonomy will run — only check that local path exists for
+        # file-based sources (worms reaches out to the network, which the
+        # step itself will fail on if unavailable).
+        if args.taxonomy_source in ("dwca", "dwc"):
+            tx_path = getattr(args, "taxonomy_path", None)
+            if tx_path is None or not Path(tx_path).exists():
+                path_str = str(tx_path) if tx_path is not None else "(not set)"
+                return (
+                    f"taxonomy.source={args.taxonomy_source!r} requires a local "
+                    f"archive but taxonomy.path={path_str!r} does not exist. "
+                    "Provide a valid DwC-A archive or DwC directory."
+                )
+        return None  # ingest_taxonomy will handle the rest
+
+    # ingest_taxonomy is NOT in the selected steps — taxonomy.sqlite must
+    # already exist for taxon annotation to work.
+    db_path = getattr(args, "taxonomy_db", None) or (args.output_dir / "taxonomy.sqlite")
+    if Path(db_path).exists():
+        return None
+
+    if args.taxonomy_source == "worms":
+        hint = (
+            "WoRMS requires internet access. HPC compute nodes are "
+            "network-restricted, so the taxonomy must be pre-built on a "
+            "login node before submitting the array job. Options:\n"
+            "  1. Run `corpus run --only ingest_taxonomy` on the login node.\n"
+            "  2. Export a WoRMS subtree as a DwC-A snapshot, copy it to "
+            "the project dir, and switch config to source: dwca."
+        )
+    else:  # dwca / dwc
+        tx_path = getattr(args, "taxonomy_path", None)
+        path_str = str(tx_path) if tx_path is not None else "(path not set)"
+        hint = (
+            f"Run `corpus run --only ingest_taxonomy` to build it from "
+            f"{path_str}."
+        )
+    return (
+        f"taxonomy.source={args.taxonomy_source!r} is configured but "
+        f"{db_path} does not exist. {hint}"
+    )
+
+
 def _should_skip_taxonomy_ingest(args: argparse.Namespace) -> bool:
     """#64: skip ingest_taxonomy when (a) no source set, or (b) the
     taxonomy SQLite already exists and the operator hasn't asked for
@@ -398,6 +463,14 @@ def main() -> int:
                      "--only extract or --only vision")
 
     selected = select_steps(args)
+
+    # Fail early if taxonomy is configured but unavailable for the selected
+    # steps — avoids a silent "no taxon annotations" corpus on HPC where
+    # compute nodes lack internet and --only skips ingest_taxonomy.
+    taxonomy_err = _check_taxonomy_available(args, selected)
+    if taxonomy_err:
+        logger.error(taxonomy_err)
+        return 1
 
     logger.info("Running %d step(s):", len(selected))
     for s in selected:

--- a/pipeline/orchestrator.py
+++ b/pipeline/orchestrator.py
@@ -101,6 +101,25 @@ class Step:
                 cmd += ["--vision-model", args.vision_model]
             if args.refresh_vision:
                 cmd.append("--refresh-vision")
+            cmd += _batch_flags(args)
+        elif self.name == "vision":
+            # HPC `--only vision` phase: re-run only Pass 3b (vision ROI
+            # detection) on existing figures.json, on the GPU partition.
+            # The extract phase may have run the CPU ocr floor, so force a
+            # vision backend here. No Grobid / taxa work — figures only.
+            cmd += [str(args.input_dir), str(args.output_dir), "--resume",
+                    "--refresh-vision", "--no-grobid", "--no-taxa"]
+            if args.dry_run:
+                cmd.append("--dry-run")
+            if args.config:
+                cmd += ["--config", str(args.config)]
+            fp = (args.figure_panels
+                  if args.figure_panels in ("vision-local", "vision-claude")
+                  else "vision-local")
+            cmd += ["--figure-panels", fp]
+            if args.vision_model:
+                cmd += ["--vision-model", args.vision_model]
+            cmd += _batch_flags(args)
         elif self.name == "embed":
             cmd += [str(args.output_dir)]
             if args.resume:
@@ -156,6 +175,62 @@ STEPS: List[Step] = [
 
 # Steps that depend on Stage 1 outputs only — usable with --skip-pipeline.
 POST_PIPELINE_STEPS = {"build_biblio", "build_taxa", "backfill_intext", "reconcile"}
+
+# The GPU Pass-3b refresh, runnable as its own phase (`--only vision`).
+# Not part of the default chain — when running the whole pipeline on one
+# node, Pass 3b happens inline inside `extract` (figures.panel_detection
+# = vision-*). It's a separate phase only so HPC can put it on a GPU
+# partition after a CPU extract pass.
+VISION_STEP = Step("vision", "pipeline.main",
+                   "Pass 3b: vision ROI refresh (GPU; --only vision)")
+
+# `--only <phase>` → the step name(s) that phase runs. ``post`` is the
+# four cross-paper builds; ``bundle`` is handled in the CLI (served-bundle
+# distill), not here.
+ONLY_PHASES = {
+    "extract": ["extract"],
+    "vision": ["vision"],
+    "embed": ["embed"],
+    "post": ["build_biblio", "build_taxa", "backfill_intext", "reconcile"],
+}
+
+
+def select_steps(args: argparse.Namespace) -> List[Step]:
+    """Resolve the ordered step list to run from the CLI args.
+
+    Precedence: ``--only <phase>`` (single HPC phase, no chaining/
+    taxonomy-autobuild) > ``--skip-pipeline`` (post-pipeline only) >
+    ``--from <step>`` (suffix) > the full chain. The ingest_taxonomy
+    autobuild step is dropped unless it's actually needed (#64).
+    """
+    if args.only is not None:
+        names = ONLY_PHASES[args.only]
+        catalog = {s.name: s for s in [*STEPS, VISION_STEP]}
+        return [catalog[n] for n in names]
+
+    if args.skip_pipeline:
+        selected = [s for s in STEPS if s.name in POST_PIPELINE_STEPS]
+    elif args.from_step is not None:
+        idx = next(i for i, s in enumerate(STEPS) if s.name == args.from_step)
+        selected = list(STEPS[idx:])
+    else:
+        selected = list(STEPS)
+
+    # #64: drop ingest_taxonomy unless we actually need to (re)build the
+    # snapshot. The other DBs handle the same via their own --rebuild.
+    if _should_skip_taxonomy_ingest(args):
+        selected = [s for s in selected if s.name != "ingest_taxonomy"]
+    return selected
+
+
+def _batch_flags(args: argparse.Namespace) -> List[str]:
+    """`--batch-index/--batch-size` passthrough for HPC array slicing
+    (#corpus-run-hpc). Both must be set; otherwise no slicing."""
+    idx = getattr(args, "batch_index", None)
+    size = getattr(args, "batch_size", None)
+    if idx is not None and size is not None:
+        return ["--batch-index", str(idx), "--batch-size", str(size)]
+    return []
 
 
 def _should_skip_taxonomy_ingest(args: argparse.Namespace) -> bool:
@@ -252,6 +327,23 @@ def main() -> int:
         choices=[s.name for s in STEPS],
         help="Start from this step (skipping all earlier steps).",
     )
+    parser.add_argument(
+        "--only", choices=list(ONLY_PHASES), default=None,
+        help="Run only one phase, instead of the full chain — for HPC "
+             "where each phase maps to a separate SLURM job/partition: "
+             "extract (CPU), vision (GPU Pass 3b refresh), embed (GPU), "
+             "post (cross-paper DBs). Omit to run the whole pipeline.",
+    )
+    parser.add_argument(
+        "--batch-index", type=int, default=None,
+        help="0-based array-task index; with --batch-size, processes a "
+             "deterministic slice of the sorted hash list (SLURM job "
+             "arrays). Applies to the extract + vision phases.",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=None,
+        help="PDFs per array task (pairs with --batch-index).",
+    )
     # #64 — auto-build cross-paper databases.
     parser.add_argument(
         "--taxonomy-source", choices=["worms", "dwc", "dwca"], default=None,
@@ -299,22 +391,13 @@ def main() -> int:
     # --resume, done.
 
     # Determine the step subset
-    if args.skip_pipeline and args.from_step:
-        parser.error("--skip-pipeline and --from are mutually exclusive")
+    if sum(bool(x) for x in (args.skip_pipeline, args.from_step, args.only)) > 1:
+        parser.error("--only, --skip-pipeline, and --from are mutually exclusive")
+    if args.batch_index is not None and args.only not in ("extract", "vision"):
+        parser.error("--batch-index/--batch-size apply only to "
+                     "--only extract or --only vision")
 
-    selected = list(STEPS)
-    if args.skip_pipeline:
-        selected = [s for s in selected if s.name in POST_PIPELINE_STEPS]
-    elif args.from_step is not None:
-        idx = next(i for i, s in enumerate(STEPS) if s.name == args.from_step)
-        selected = STEPS[idx:]
-
-    # #64: drop ingest_taxonomy if we don't need to (re)build the
-    # snapshot — this is the auto-detect part of "auto-build" cross-paper
-    # databases. The other DBs (biblio_authority, taxon_mentions) handle
-    # the same logic via their own --rebuild flags applied per-DB above.
-    if _should_skip_taxonomy_ingest(args):
-        selected = [s for s in selected if s.name != "ingest_taxonomy"]
+    selected = select_steps(args)
 
     logger.info("Running %d step(s):", len(selected))
     for s in selected:

--- a/pipeline/orchestrator.py
+++ b/pipeline/orchestrator.py
@@ -277,11 +277,15 @@ def _check_taxonomy_available(
         return None
 
     if args.taxonomy_source == "worms":
+        root_id = getattr(args, "taxonomy_root_id", None)
+        root_flag = f" --root-id {root_id}" if root_id else " --root-id <aphia_id>"
         hint = (
             "WoRMS requires internet access. HPC compute nodes are "
             "network-restricted, so the taxonomy must be pre-built on a "
-            "login node before submitting the array job. Options:\n"
-            "  1. Run `corpus run --only ingest_taxonomy` on the login node.\n"
+            "login node (which allows small outbound API calls) before "
+            "submitting the array job. Options:\n"
+            f"  1. Run `corpus taxonomy ingest --source worms{root_flag}` "
+            "on the login node.\n"
             "  2. Export a WoRMS subtree as a DwC-A snapshot, copy it to "
             "the project dir, and switch config to source: dwca."
         )
@@ -289,8 +293,8 @@ def _check_taxonomy_available(
         tx_path = getattr(args, "taxonomy_path", None)
         path_str = str(tx_path) if tx_path is not None else "(path not set)"
         hint = (
-            f"Run `corpus run --only ingest_taxonomy` to build it from "
-            f"{path_str}."
+            f"Run `corpus taxonomy ingest --source {args.taxonomy_source} "
+            f"--input {path_str}` to build it from the archive."
         )
     return (
         f"taxonomy.source={args.taxonomy_source!r} is configured but "

--- a/slurm/batch_biblio.sh
+++ b/slurm/batch_biblio.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=biblio-authority
 #SBATCH --partition=week
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=8G
+#SBATCH --mem=32G
 #SBATCH --time=7-00:00:00
 #SBATCH --output=logs/slurm-biblio-%j.out
 #SBATCH --error=logs/slurm-biblio-%j.err

--- a/slurm/batch_embed.sh
+++ b/slurm/batch_embed.sh
@@ -3,7 +3,7 @@
 #SBATCH --partition=gpu
 #SBATCH --gpus=1
 #SBATCH --cpus-per-task=4
-#SBATCH --mem-per-cpu=8G
+#SBATCH --mem-per-cpu=16G
 #SBATCH --time=4:00:00
 #SBATCH --output=logs/slurm-embed-%j.out
 #SBATCH --error=logs/slurm-embed-%j.err

--- a/slurm/batch_embed.sh
+++ b/slurm/batch_embed.sh
@@ -44,11 +44,10 @@ mkdir -p logs
 # ── Run ──────────────────────────────────────────────────────────────
 echo "Starting embedding pass at $(date)"
 echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'unknown')"
-echo "Output: $OUTPUT_DIR"
+echo "Config: $CORPUS_CONFIG"
 
-python -m pipeline.embed \
-    "$OUTPUT_DIR" \
-    --resume || {
+# Embed phase only (BGE-M3 → LanceDB). Resume is implicit (#138).
+corpus -c "$CORPUS_CONFIG" run --only embed || {
     EC=$?
     # Bus error (135) or segfault (139) during CUDA teardown after
     # successful embedding is a known issue on RTX 5000 Ada nodes with
@@ -57,7 +56,7 @@ python -m pipeline.embed \
     if [ $EC -eq 135 ] || [ $EC -eq 139 ]; then
         echo "WARNING: Bus error during cleanup (exit $EC) — embeddings are complete"
     else
-        echo "ERROR: pipeline.embed failed with exit code $EC"
+        echo "ERROR: corpus run --only embed failed with exit code $EC"
         exit $EC
     fi
 }

--- a/slurm/batch_finalize.sh
+++ b/slurm/batch_finalize.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=corpus-finalize
 #SBATCH --partition=day
 #SBATCH --cpus-per-task=2
-#SBATCH --mem=8G
+#SBATCH --mem=32G
 #SBATCH --time=12:00:00
 #SBATCH --output=logs/slurm-finalize-%j.out
 #SBATCH --error=logs/slurm-finalize-%j.err

--- a/slurm/batch_finalize.sh
+++ b/slurm/batch_finalize.sh
@@ -39,39 +39,32 @@ source "$SCRIPT_DIR/bouchet_paths.sh"
 cd "$REPO_DIR"
 
 ENRICH_BHL="${ENRICH_BHL:-0}"
-SERVE_BUNDLE_DIR="${SERVE_BUNDLE_DIR:-}"
+SKIP_BUNDLE="${SKIP_BUNDLE:-0}"
 
 echo "=== Cross-paper finalize at $(date) ==="
-echo "Output dir:  $OUTPUT_DIR"
+echo "Config:      $CORPUS_CONFIG"
 echo "BHL enrich:  $ENRICH_BHL"
-echo "Serve bundle: ${SERVE_BUNDLE_DIR:-<none>}"
+echo "Skip bundle: $SKIP_BUNDLE"
 
-BHL_FLAG=""
+BHL_FLAG=()
 if [ "$ENRICH_BHL" = "1" ]; then
-    BHL_FLAG="--enrich-bhl"
+    BHL_FLAG=(--enrich-bhl)
 fi
 
-# 1. Bibliographic authority DB (and apply any sidecar from #67)
-echo "── build_biblio ──────────────────────────────────────────────"
-python -m bib.authority "$OUTPUT_DIR" $BHL_FLAG -v
+# Post phase: the four cross-paper builds (biblio authority → taxon
+# mentions → in-text citation backfill → reconcile) now run in dependency
+# order inside `corpus run --only post` instead of four raw module
+# invocations (#138).
+echo "── post (cross-paper DBs) ────────────────────────────────────"
+corpus -c "$CORPUS_CONFIG" run --only post "${BHL_FLAG[@]}"
 
-# 2. Taxon mention rollup
-echo "── build_taxa ────────────────────────────────────────────────"
-python -m pipeline.taxon_mentions "$OUTPUT_DIR" -v
-
-# 3. In-text citation backfill from TEI bodies
-echo "── backfill_intext ───────────────────────────────────────────"
-python -m pipeline.intext_citations "$OUTPUT_DIR"
-
-# 4. Reconcile ghost cited-references onto corpus papers
-echo "── reconcile ─────────────────────────────────────────────────"
-python -m bib.reconcile "$OUTPUT_DIR"
-
-# 5. Optional: distill into a served bundle
-if [ -n "$SERVE_BUNDLE_DIR" ]; then
-    VERSION="$(python -c 'from pipeline.version import __version__; print(__version__)')"
-    echo "── package_for_serve → $SERVE_BUNDLE_DIR (v$VERSION) ─────────"
-    python -m mcpsrv.bundle "$OUTPUT_DIR" "$SERVE_BUNDLE_DIR" --version "$VERSION"
+# Bundle phase: distill the served bundle into <output_dir>/_serve/.
+# This supersedes the old SERVE_BUNDLE_DIR / `mcpsrv.bundle` step — the
+# served bundle now always lands at _serve/ (DEPLOY.md). Set SKIP_BUNDLE=1
+# to stop after the cross-paper DBs.
+if [ "$SKIP_BUNDLE" != "1" ]; then
+    echo "── bundle (served-bundle distill → _serve/) ──────────────────"
+    corpus -c "$CORPUS_CONFIG" run --only bundle
 fi
 
 echo "=== Cross-paper finalize complete at $(date) ==="

--- a/slurm/batch_finalize.sh
+++ b/slurm/batch_finalize.sh
@@ -38,6 +38,12 @@ source "$SCRIPT_DIR/bouchet_paths.sh"
 
 cd "$REPO_DIR"
 
+# ── Environment ──────────────────────────────────────────────────────
+module purge
+module load miniconda
+eval "$(conda shell.bash hook)"
+conda activate corpus
+
 ENRICH_BHL="${ENRICH_BHL:-0}"
 SKIP_BUNDLE="${SKIP_BUNDLE:-0}"
 

--- a/slurm/batch_grobid.sh
+++ b/slurm/batch_grobid.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=grobid
 #SBATCH --partition=day
 #SBATCH --cpus-per-task=4
-#SBATCH --mem=16G
+#SBATCH --mem=32G
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/slurm-grobid-%j.out
 #SBATCH --error=logs/slurm-grobid-%j.err

--- a/slurm/batch_pass3b.sh
+++ b/slurm/batch_pass3b.sh
@@ -81,17 +81,14 @@ if [ -n "${SLURM_ARRAY_TASK_ID:-}" ]; then
     echo "Array task $SLURM_ARRAY_TASK_ID, batch size $BATCH_SIZE"
 fi
 
-PY_ARGS=(
-    "$INPUT_DIR" "$OUTPUT_DIR"
-    --resume
-    --refresh-vision
-    --no-grobid
-    --no-taxa
-    --figure-panels vision-local
-    "${BATCH_ARGS[@]}"
-)
-echo "python args: -m pipeline.main ${PY_ARGS[*]}"
+# Vision phase only (Pass 3b + 3c). The `--only vision` orchestrator step
+# already forces --refresh-vision / --no-grobid / --no-taxa internally;
+# we only pin the backend to the local Qwen2.5-VL with --figure-panels
+# vision-local. Resume is implicit. No Grobid needed (#138).
+echo "corpus -c $CORPUS_CONFIG run --only vision --figure-panels vision-local ${BATCH_ARGS[*]}"
 
-python -m pipeline.main "${PY_ARGS[@]}"
+corpus -c "$CORPUS_CONFIG" run --only vision \
+    --figure-panels vision-local \
+    "${BATCH_ARGS[@]}"
 
 echo "Pass 3b + 3c completed at $(date)"

--- a/slurm/batch_pass3b.sh
+++ b/slurm/batch_pass3b.sh
@@ -3,7 +3,7 @@
 #SBATCH --partition=gpu_h200
 #SBATCH --gpus=h200:1
 #SBATCH --cpus-per-task=8
-#SBATCH --mem-per-cpu=8G
+#SBATCH --mem-per-cpu=16G
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/slurm-pass3b-%A_%a.out
 #SBATCH --error=logs/slurm-pass3b-%A_%a.err

--- a/slurm/batch_pipeline.sh
+++ b/slurm/batch_pipeline.sh
@@ -105,7 +105,7 @@ echo "  Grobid cancel job: $CANCEL_JOB (runs after Stage 1)"
 
 # ── Step 6: Submit Pass 3b and Embed (depend on Stage 1) ────────────
 echo ""
-NUM_PASS3B_BATCHES="${NUM_PASS3B_BATCHES:-1}"
+NUM_PASS3B_BATCHES="${NUM_PASS3B_BATCHES:-$NUM_BATCHES}"
 PASS3B_BATCH_SIZE="${PASS3B_BATCH_SIZE:-256}"
 echo "Submitting Pass 3b (vision, GPU; $NUM_PASS3B_BATCHES batch(es) of $PASS3B_BATCH_SIZE)..."
 if [ "$NUM_PASS3B_BATCHES" -gt 1 ]; then

--- a/slurm/batch_process_corpus.sh
+++ b/slurm/batch_process_corpus.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name=corpus-stage1
 #SBATCH --partition=day
 #SBATCH --cpus-per-task=8
-#SBATCH --mem=128G
+#SBATCH --mem=256G
 #SBATCH --time=24:00:00
 #SBATCH --output=logs/slurm-stage1-%A_%a.out
 #SBATCH --error=logs/slurm-stage1-%A_%a.err

--- a/slurm/batch_process_corpus.sh
+++ b/slurm/batch_process_corpus.sh
@@ -65,56 +65,41 @@ print(f'docling + torch loaded OK ({torch.__version__})')
 "
 
 # ── Grobid ───────────────────────────────────────────────────────────
-GROBID_URL="${GROBID_URL:-http://localhost:8070}"
-echo "Grobid URL: $GROBID_URL"
-
-# Quick health check — warn but don't abort (pipeline has --no-grobid fallback)
-if ! curl -fsS "$GROBID_URL/api/isalive" >/dev/null 2>&1; then
-    echo "WARNING: Grobid not reachable at $GROBID_URL — metadata will use fallback"
+# $CORPUS_CONFIG is the source of truth for the Grobid address. When
+# batch_pipeline.sh discovers the dynamically-allocated Grobid node it
+# exports $GROBID_URL, which `corpus run` honors as an override (#138).
+# Submitted standalone (no override), the grobid.url from config.yaml is
+# used. Only export when explicitly set, so we never shadow the config.
+if [ -n "${GROBID_URL:-}" ]; then
+    export GROBID_URL
+    echo "Grobid URL (override): $GROBID_URL"
+    # Warn but don't abort — config may set grobid.disable, and the
+    # pipeline degrades to header-fallback metadata if Grobid is down.
+    if ! curl -fsS "$GROBID_URL/api/isalive" >/dev/null 2>&1; then
+        echo "WARNING: Grobid not reachable at $GROBID_URL — metadata will use fallback"
+    fi
+else
+    echo "Grobid URL: from $CORPUS_CONFIG (no \$GROBID_URL override)"
 fi
 
-# ── Taxonomy + lexicon (if available) ────────────────────────────────
-# Taxonomy: built by ingest_taxonomy.py (any DwC source — WoRMS, GBIF,
-# iNaturalist, or a curated CSV). Optional; pipeline degrades gracefully
-# if absent. Lexicon: a single multi-category YAML; top-level keys are
-# categories (anatomy, biogeography, …). See demo/lexicon.yaml.
-TAXONOMY_FLAG=""
-if [ -f "$OUTPUT_DIR/taxonomy.sqlite" ]; then
-    TAXONOMY_FLAG="--taxonomy-db $OUTPUT_DIR/taxonomy.sqlite"
-fi
-
-LEXICON_FLAG=""
-if [ -f "${LEXICON:-}" ]; then
-    LEXICON_FLAG="--lexicon $LEXICON"
-elif [ -f "$OUTPUT_DIR/lexicon.yaml" ]; then
-    LEXICON_FLAG="--lexicon $OUTPUT_DIR/lexicon.yaml"
-fi
-
-BIB_FLAG=""
-if [ -f "${BIB_FILE:-}" ]; then
-    BIB_FLAG="--bib $BIB_FILE"
-fi
+# Inputs (taxonomy, lexicon, bib) are no longer passed as flags — they
+# live in $CORPUS_CONFIG and `corpus run` reads them from there (#138).
 
 # ── Batch parameters (for SLURM job arrays) ─────────────────────────
 BATCH_SIZE="${BATCH_SIZE:-256}"
-BATCH_ARGS=""
+BATCH_ARGS=()
 if [ -n "${SLURM_ARRAY_TASK_ID:-}" ]; then
-    BATCH_ARGS="--batch-index $SLURM_ARRAY_TASK_ID --batch-size $BATCH_SIZE"
+    BATCH_ARGS=(--batch-index "$SLURM_ARRAY_TASK_ID" --batch-size "$BATCH_SIZE")
     echo "Array task $SLURM_ARRAY_TASK_ID, batch size $BATCH_SIZE"
 fi
 
 # ── Run ──────────────────────────────────────────────────────────────
-echo "Starting Stage 1 processing at $(date)"
-echo "Input:  $INPUT_DIR"
-echo "Output: $OUTPUT_DIR"
+# Extract phase only: OCR → docling → Grobid metadata → chunking → taxa +
+# lexicon tagging. Resume is implicit; $GROBID_URL overrides the config's
+# Grobid address (set above / by batch_pipeline.sh).
+echo "Starting Stage 1 (extract) at $(date)"
+echo "Config: $CORPUS_CONFIG"
 
-python -m pipeline.main \
-    "$INPUT_DIR" "$OUTPUT_DIR" \
-    --resume \
-    --grobid-url "$GROBID_URL" \
-    $TAXONOMY_FLAG \
-    $LEXICON_FLAG \
-    $BIB_FLAG \
-    $BATCH_ARGS
+corpus -c "$CORPUS_CONFIG" run --only extract "${BATCH_ARGS[@]}"
 
 echo "Stage 1 completed at $(date)"

--- a/slurm/bouchet_paths.sh
+++ b/slurm/bouchet_paths.sh
@@ -22,13 +22,13 @@ REPO_DIR="${REPO_DIR:-$BOUCHET_PROJECT/corpus}"
 # Corpuscles live under $BOUCHET_PROJECT/corpuscles/<name>_YYYYMMDD/.
 # Update this line when starting a new build; the date is the build date.
 # Sample runs follow the same convention (siphonophore_sample_YYYYMMDD).
-CORPUS_CONFIG="${CORPUS_CONFIG:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260601/config.yaml}"
+CORPUS_CONFIG="${CORPUS_CONFIG:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260603/config.yaml}"
 
 # Legacy path vars — still consumed by the not-yet-ported helper scripts
 # (batch_grobid.sh, batch_biblio.sh) and by batch_pipeline.sh's banner.
 # Keep them in sync with the matching keys in $CORPUS_CONFIG.
 INPUT_DIR="${INPUT_DIR:-$BOUCHET_PROJECT/siphonophores/library}"
-OUTPUT_DIR="${OUTPUT_DIR:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260601}"
+OUTPUT_DIR="${OUTPUT_DIR:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260603}"
 BIB_FILE="${BIB_FILE:-$BOUCHET_PROJECT/siphonophores/siphonophores.bib}"
 LEXICON="${LEXICON:-$BOUCHET_PROJECT/siphonophores/lexicon.yaml}"
 CACHE_DIR="${CACHE_DIR:-$BOUCHET_PROJECT/cache}"

--- a/slurm/bouchet_paths.sh
+++ b/slurm/bouchet_paths.sh
@@ -11,6 +11,19 @@
 BOUCHET_PROJECT="${BOUCHET_PROJECT:-/nfs/roberts/project/pi_cwd7/cwd7}"
 
 REPO_DIR="${REPO_DIR:-$BOUCHET_PROJECT/corpus}"
+
+# Corpuscle config.yaml — the source of truth for the new `corpus run`
+# flow (#138). input_pdfs / output_dir / bib / lexicon / taxonomy / grobid
+# now live INSIDE this file, not as CLI flags. The phase scripts
+# (batch_process_corpus, batch_pass3b, batch_embed, batch_finalize) drive
+# `corpus -c "$CORPUS_CONFIG" run --only <phase>`. See BOUCHET.md for how
+# to author it. The dynamic Grobid node URL is still injected at submit
+# time via $GROBID_URL, which `corpus run` honors as an override.
+CORPUS_CONFIG="${CORPUS_CONFIG:-$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml}"
+
+# Legacy path vars — still consumed by the not-yet-ported helper scripts
+# (batch_grobid.sh, batch_biblio.sh) and by batch_pipeline.sh's banner.
+# Keep them in sync with the matching keys in $CORPUS_CONFIG.
 INPUT_DIR="${INPUT_DIR:-$BOUCHET_PROJECT/siphonophores/library}"
 OUTPUT_DIR="${OUTPUT_DIR:-$BOUCHET_PROJECT/siphonophore_corpuscle}"
 BIB_FILE="${BIB_FILE:-$BOUCHET_PROJECT/siphonophores/siphonophores.bib}"

--- a/slurm/bouchet_paths.sh
+++ b/slurm/bouchet_paths.sh
@@ -19,13 +19,16 @@ REPO_DIR="${REPO_DIR:-$BOUCHET_PROJECT/corpus}"
 # `corpus -c "$CORPUS_CONFIG" run --only <phase>`. See BOUCHET.md for how
 # to author it. The dynamic Grobid node URL is still injected at submit
 # time via $GROBID_URL, which `corpus run` honors as an override.
-CORPUS_CONFIG="${CORPUS_CONFIG:-$BOUCHET_PROJECT/siphonophore_corpuscle/config.yaml}"
+# Corpuscles live under $BOUCHET_PROJECT/corpuscles/<name>_YYYYMMDD/.
+# Update this line when starting a new build; the date is the build date.
+# Sample runs follow the same convention (siphonophore_sample_YYYYMMDD).
+CORPUS_CONFIG="${CORPUS_CONFIG:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260601/config.yaml}"
 
 # Legacy path vars — still consumed by the not-yet-ported helper scripts
 # (batch_grobid.sh, batch_biblio.sh) and by batch_pipeline.sh's banner.
 # Keep them in sync with the matching keys in $CORPUS_CONFIG.
 INPUT_DIR="${INPUT_DIR:-$BOUCHET_PROJECT/siphonophores/library}"
-OUTPUT_DIR="${OUTPUT_DIR:-$BOUCHET_PROJECT/siphonophore_corpuscle}"
+OUTPUT_DIR="${OUTPUT_DIR:-$BOUCHET_PROJECT/corpuscles/siphonophore_20260601}"
 BIB_FILE="${BIB_FILE:-$BOUCHET_PROJECT/siphonophores/siphonophores.bib}"
 LEXICON="${LEXICON:-$BOUCHET_PROJECT/siphonophores/lexicon.yaml}"
 CACHE_DIR="${CACHE_DIR:-$BOUCHET_PROJECT/cache}"

--- a/tests/test_corpus_run_hpc.py
+++ b/tests/test_corpus_run_hpc.py
@@ -146,3 +146,43 @@ def test_batch_flags_need_both():
     assert orch._batch_flags(_argv_args(batch_index=1)) == []  # size missing
     assert orch._batch_flags(_argv_args(batch_index=1, batch_size=2)) == \
         ["--batch-index", "1", "--batch-size", "2"]
+
+
+# --- $GROBID_URL override (#138) ---------------------------------------------
+
+
+def test_grobid_url_env_overrides_config(tmp_path, monkeypatch):
+    """$GROBID_URL beats the static config.yaml address (#138).
+
+    On HPC, Grobid runs on a dynamically-allocated compute node whose
+    hostname isn't known until submit time, so config.yaml can't name it;
+    slurm/batch_pipeline.sh discovers the node and exports GROBID_URL.
+    The override must reach the orchestrator argv.
+    """
+    (tmp_path / "pdfs").mkdir()
+    (tmp_path / "config.yaml").write_text(
+        "input_pdfs: ./pdfs\noutput_dir: ./output\n"
+        "grobid:\n  url: http://static:8070\n"
+    )
+    captured = {}
+
+    def fake_run(cmd, *a, **k):
+        captured["cmd"] = cmd
+
+        class _R:
+            returncode = 0
+        return _R()
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setenv("GROBID_URL", "http://dynamic-node:8070")
+
+    # --only vision skips preconditions/prune, so the run goes straight to
+    # argv build + subprocess. --dry-run keeps it side-effect-free.
+    args = _run_args(only="vision", dry_run=True,
+                     config=tmp_path / "config.yaml")
+    assert cli._cmd_run(args) == cli.EXIT_OK
+
+    cmd = captured["cmd"]
+    assert "--grobid-url" in cmd
+    assert "http://dynamic-node:8070" in cmd
+    assert "http://static:8070" not in cmd

--- a/tests/test_corpus_run_hpc.py
+++ b/tests/test_corpus_run_hpc.py
@@ -1,0 +1,148 @@
+"""`corpus run` HPC phases — single-phase + array slicing.
+
+Makes `corpus run` usable on HPC (one phase per SLURM job/partition,
+job-array slicing) so the production path is the same CLI users run,
+instead of a divergent raw-`pipeline.main` reimplementation.
+
+Covers:
+- `corpus run --only {extract,vision,embed,post,bundle}` + `--batch-index`
+  / `--batch-size` parse, and their passthrough to the orchestrator.
+- The orchestrator's `select_steps` phase resolution.
+- The orchestrator extract/vision step argv (batch flags, vision forces
+  a vision backend).
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+import pipeline.cli as cli
+import pipeline.orchestrator as orch
+from pipeline.config_schema import validate_config
+
+
+# --- CLI: parse + _build_orchestrator_argv passthrough -----------------------
+
+
+def _cfg(tmp_path: Path):
+    (tmp_path / "pdfs").mkdir(exist_ok=True)
+    return validate_config({
+        "input_pdfs": "./pdfs", "output_dir": "./output",
+        "grobid": {"disable": True, "url": ""},
+    })
+
+
+def _run_args(**overrides):
+    base = dict(
+        force_rebuild=False, dry_run=False, no_vision=False, figure_panels=None,
+        enrich_bhl=False, force_rebuild_taxonomy=False, force_rebuild_biblio=False,
+        force_rebuild_taxon_mentions=False, only=None, batch_index=None,
+        batch_size=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _argv(tmp_path, **arg_overrides):
+    return cli._build_orchestrator_argv(
+        _cfg(tmp_path), tmp_path / "config.yaml", _run_args(**arg_overrides))
+
+
+def test_run_parses_only_and_batch_flags():
+    p = cli._build_parser()
+    a = p.parse_args(["run", "--only", "extract", "--batch-index", "3",
+                      "--batch-size", "256"])
+    assert a.only == "extract" and a.batch_index == 3 and a.batch_size == 256
+    assert p.parse_args(["run"]).only is None  # default = full run
+
+
+def test_build_argv_forwards_only_and_batch(tmp_path):
+    argv = _argv(tmp_path, only="extract", batch_index=2, batch_size=128)
+    assert "--only" in argv and argv[argv.index("--only") + 1] == "extract"
+    assert "--batch-index" in argv and argv[argv.index("--batch-index") + 1] == "2"
+    assert "--batch-size" in argv and argv[argv.index("--batch-size") + 1] == "128"
+
+
+def test_build_argv_omits_only_for_full_run(tmp_path):
+    assert "--only" not in _argv(tmp_path)  # no --only → full chain
+
+
+def test_build_argv_never_forwards_bundle(tmp_path):
+    # bundle is a CLI-level phase, handled before the orchestrator runs.
+    assert "--only" not in _argv(tmp_path, only="bundle")
+
+
+# --- orchestrator: select_steps phase resolution -----------------------------
+
+
+def _orch_args(**overrides):
+    base = dict(only=None, skip_pipeline=False, from_step=None,
+                taxonomy_source=None, force_rebuild=False,
+                force_rebuild_taxonomy=False, output_dir=Path("/nope"),
+                batch_index=None, batch_size=None)
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+@pytest.mark.parametrize("phase,expected", [
+    ("extract", ["extract"]),
+    ("vision", ["vision"]),
+    ("embed", ["embed"]),
+    ("post", ["build_biblio", "build_taxa", "backfill_intext", "reconcile"]),
+])
+def test_select_steps_only_phase(phase, expected):
+    names = [s.name for s in orch.select_steps(_orch_args(only=phase))]
+    assert names == expected
+
+
+def test_select_steps_full_run_has_no_vision_step():
+    # vision runs inline in extract on a full run; it's a separate step
+    # only via --only vision.
+    names = [s.name for s in orch.select_steps(_orch_args())]
+    assert "vision" not in names
+    assert "extract" in names and "embed" in names
+
+
+# --- orchestrator: step argv (batch slicing + vision backend) ----------------
+
+
+def _argv_args(**overrides):
+    base = dict(
+        input_dir=Path("/in"), output_dir=Path("/out"), resume=True,
+        dry_run=False, config=None, bib=None, taxonomy_db=None, lexicon=None,
+        no_taxa=False, no_grobid=False, grobid_url=None, strict_network=False,
+        figure_panels="ocr", vision_model=None, refresh_vision=False,
+        batch_index=None, batch_size=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def test_extract_step_carries_batch_flags():
+    step = next(s for s in orch.STEPS if s.name == "extract")
+    argv = step.argv(_argv_args(batch_index=4, batch_size=64))
+    assert "--batch-index" in argv and "4" in argv
+    assert "--batch-size" in argv and "64" in argv
+
+
+def test_vision_step_forces_vision_backend_and_refresh():
+    argv = orch.VISION_STEP.argv(_argv_args(figure_panels="ocr",
+                                            batch_index=1, batch_size=8))
+    assert "--refresh-vision" in argv
+    # extract phase used the ocr floor; vision phase must force a backend
+    assert argv[argv.index("--figure-panels") + 1] == "vision-local"
+    assert "--no-grobid" in argv and "--no-taxa" in argv
+    assert "--batch-index" in argv
+
+
+def test_vision_step_honors_configured_vision_backend():
+    argv = orch.VISION_STEP.argv(_argv_args(figure_panels="vision-claude"))
+    assert argv[argv.index("--figure-panels") + 1] == "vision-claude"
+
+
+def test_batch_flags_need_both():
+    assert orch._batch_flags(_argv_args(batch_index=1)) == []  # size missing
+    assert orch._batch_flags(_argv_args(batch_index=1, batch_size=2)) == \
+        ["--batch-index", "1", "--batch-size", "2"]

--- a/tools/smoke_test_sse.py
+++ b/tools/smoke_test_sse.py
@@ -19,6 +19,11 @@ Runs three layers against a locally-launched ``python -m mcpsrv.main``:
             corpus-specific content — suitable for both the 4-paper
             demo and a full production corpuscle.
 
+            Layer 3 includes ``get_chunks_for_topic`` (semantic search),
+            which loads the ~600 MB BGE-M3 embedding model on first
+            call.  Run on a compute node (``salloc`` / batch job) for
+            full coverage; on a CPU-only login node the server may OOM.
+
 Starts the server as a subprocess, waits for it to bind, runs the
 checks, shuts it down cleanly.  No external deps — stdlib for layer
 1, the ``mcp`` Python SDK (already a dep) for layers 2 and 3.
@@ -249,12 +254,16 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
             await session.initialize()
 
             # ── Discover a real paper hash for paper-keyed tests ────
+            # limit=1 returns one item → one content block → dict.
+            # Handle both dict (single item) and list (multi) cases.
             first_hash = None
             try:
                 r = await session.call_tool("list_papers", {"limit": 1})
                 papers = _parse_tool_result(r)
                 if isinstance(papers, list) and papers:
                     first_hash = papers[0].get("hash")
+                elif isinstance(papers, dict):
+                    first_hash = papers.get("hash")
             except Exception:
                 pass
 
@@ -263,9 +272,11 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
             try:
                 r = await session.call_tool("corpus_summary", {})
                 d = _parse_tool_result(r)
-                if isinstance(d, dict) and "paper_count" in d and d["paper_count"] > 0:
-                    _ok(f"corpus_summary → {d['paper_count']} papers, "
-                        f"{d.get('chunk_count', '?')} chunks")
+                # key is n_papers (not paper_count)
+                if isinstance(d, dict) and d.get("n_papers", 0) > 0:
+                    _ok(f"corpus_summary → {d['n_papers']} papers, "
+                        f"{d.get('n_unique_taxa', '?')} taxa, "
+                        f"{d.get('n_figures_total', '?')} figures")
                 else:
                     rc |= _fail(f"corpus_summary unexpected: {d!r}")
             except Exception as e:
@@ -283,15 +294,18 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
                     "search_taxon", {"name": "Siphonophorae"}
                 )
                 d = _parse_tool_result(r)
-                if isinstance(d, dict) and "found" in d:
-                    if d["found"]:
-                        taxon_hit = d.get("taxon_id") or "Siphonophorae"
-                        _ok(f"search_taxon(Siphonophorae) → found, "
-                            f"taxon_id={d.get('taxon_id')!r}")
-                    else:
-                        # Demo corpus may not have siphonophore taxonomy
-                        _ok("search_taxon(Siphonophorae) → not found "
-                            "(expected on demo corpus)")
+                # success: {matched_taxon_id, accepted_name, ...}
+                # not-found: {not_found: True, queried: name}
+                if isinstance(d, dict) and "matched_taxon_id" in d:
+                    taxon_hit = d.get("accepted_taxon_id") or "Siphonophorae"
+                    _ok(f"search_taxon(Siphonophorae) → found, "
+                        f"accepted={d.get('accepted_name')!r}, "
+                        f"in_corpus={d.get('in_corpus')}")
+                elif isinstance(d, dict) and d.get("not_found"):
+                    _ok("search_taxon(Siphonophorae) → not found "
+                        "(expected on demo corpus)")
+                elif isinstance(d, dict) and "error" in d:
+                    _ok(f"search_taxon → error (no taxonomy? {d['error']!r})")
                 else:
                     rc |= _fail(f"search_taxon unexpected: {d!r}")
             except Exception as e:
@@ -310,6 +324,9 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
                 elif isinstance(d, dict) and "error" in d:
                     _ok(f"list_valid_species_under → error (expected on "
                         f"demo: {d['error']!r})")
+                elif isinstance(d, dict) and "accepted_taxon_id" in d:
+                    # Single-item list serialised as one block → dict
+                    _ok("list_valid_species_under → 1 species (dict form)")
                 else:
                     rc |= _fail(f"list_valid_species_under unexpected: {d!r}")
             except Exception as e:
@@ -359,15 +376,17 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
             _section("Layer 3c: chunk tools")
 
             # get_chunks_for_topic — semantic search, requires LanceDB
+            # and loads the ~600 MB BGE-M3 embedder on first call.
+            # Run on a compute node for full coverage.
             try:
                 r = await session.call_tool(
                     "get_chunks_for_topic",
-                    {"topic": "nectophore morphology", "limit": 3},
+                    {"query": "nectophore morphology", "k": 3},
                 )
                 d = _parse_tool_result(r)
                 if isinstance(d, list):
                     _ok(f"get_chunks_for_topic → {len(d)} chunks")
-                    if d:
+                    if d and isinstance(d[0], dict):
                         has_text = "text" in d[0] or "chunk_id" in d[0]
                         if not has_text:
                             rc |= _fail(
@@ -428,6 +447,12 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
                 d = _parse_tool_result(r)
                 if isinstance(d, list):
                     _ok(f"get_missing_references → {len(d)} missing refs")
+                elif isinstance(d, dict) and "error" in d:
+                    _ok(f"get_missing_references → error (no biblio DB? "
+                        f"{d['error']!r})")
+                elif isinstance(d, dict) and "work_id" in d:
+                    # Single-item list → one block → dict
+                    _ok("get_missing_references → 1 ref (dict form)")
                 else:
                     rc |= _fail(f"get_missing_references unexpected: {type(d)}")
             except Exception as e:
@@ -454,16 +479,19 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
             try:
                 r = await session.call_tool(
                     "lexicon_matrix",
-                    {"category": "anatomy", "max_terms": 5, "max_papers": 5},
+                    {"category": "anatomy"},
                 )
                 d = _parse_tool_result(r)
                 if isinstance(d, dict):
                     if "error" in d:
                         _ok(f"lexicon_matrix → error (no lexicon? "
                             f"{d['error']!r})")
-                    elif "terms" in d or "matrix" in d or "papers" in d:
-                        _ok(f"lexicon_matrix(anatomy) → keys: "
-                            f"{sorted(d)[:5]}")
+                    elif "term_totals" in d or "terms" in d:
+                        # detail=False → {category, detail, paper_count, term_totals}
+                        # detail=True  → {category, detail, terms, rows}
+                        n = (len(d.get("term_totals") or d.get("terms") or []))
+                        _ok(f"lexicon_matrix(anatomy) → {n} terms, "
+                            f"paper_count={d.get('paper_count', '?')}")
                     else:
                         rc |= _fail(
                             f"lexicon_matrix unexpected keys: {sorted(d)}"
@@ -487,6 +515,9 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
                 elif isinstance(d, dict) and "error" in d:
                     _ok(f"get_figures_for_taxon → error (demo OK: "
                         f"{d['error']!r})")
+                elif isinstance(d, dict) and "figure_id" in d:
+                    # Single figure serialised as one block → dict
+                    _ok(f"get_figures_for_taxon(Physalia) → 1 figure (dict form)")
                 else:
                     rc |= _fail(
                         f"get_figures_for_taxon unexpected: {type(d)}"
@@ -516,17 +547,31 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
 
 def _parse_tool_result(result):
     """Best-effort extraction of a JSON payload from an MCP tool
-    result's content blocks.  Returns the parsed value or None."""
+    result's content blocks.  Returns the parsed value or None.
+
+    The MCP framework serialises Python list returns as one content
+    block per item (not as a single JSON array block).  When we see
+    multiple parseable blocks we re-assemble them into a list so
+    callers can do ``isinstance(d, list)`` normally.
+    """
+    blocks = []
     for block in getattr(result, "content", []) or []:
         text = getattr(block, "text", None)
         if not text:
             continue
         try:
-            return json.loads(text)
+            blocks.append(json.loads(text))
         except Exception:
-            # Some tools return plain text — hand that back as-is.
-            return text
-    return None
+            # Plain-text block — keep it so we don't lose single
+            # plain-text responses.
+            blocks.append(text)
+    if not blocks:
+        return None
+    if len(blocks) == 1:
+        return blocks[0]
+    # Multiple blocks → the server serialised a list one item per
+    # block; re-assemble.
+    return blocks
 
 
 # ── Orchestration ───────────────────────────────────────────────────

--- a/tools/smoke_test_sse.py
+++ b/tools/smoke_test_sse.py
@@ -432,6 +432,15 @@ async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
                     if isinstance(d, list):
                         _ok(f"get_bibliography({first_hash[:8]}…) → "
                             f"{len(d)} refs")
+                    elif d is None:
+                        # get_bibliography returns a bare list; an empty
+                        # one (paper with no parsed references — common on
+                        # the demo corpus and on scanned/old papers) is
+                        # serialised as zero content blocks, so
+                        # _parse_tool_result yields None. That's a valid
+                        # empty result, not a failure.
+                        _ok(f"get_bibliography({first_hash[:8]}…) → 0 refs "
+                            f"(empty)")
                     else:
                         rc |= _fail(f"get_bibliography unexpected: {type(d)}")
                 except Exception as e:

--- a/tools/smoke_test_sse.py
+++ b/tools/smoke_test_sse.py
@@ -1,24 +1,32 @@
 #!/usr/bin/env python3
 """Smoke-test the MCP server's SSE transport + bearer-token auth.
 
-Runs two layers against a locally-launched ``python -m mcpsrv.main``:
+Runs three layers against a locally-launched ``python -m mcpsrv.main``:
 
   Layer 1 — raw HTTP: unauthenticated → 401, wrong-token → 401,
             correct-token → 200 with ``Content-Type: text/event-stream``.
             Catches middleware / uvicorn / binding issues.
 
-  Layer 2 — real MCP client: initialize handshake, ``list_tools``,
+  Layer 2 — MCP handshake: initialize, ``list_tools``,
             ``call_tool(bundle_info)``, ``call_tool(list_papers,
             limit=1)``.  Catches framing, keepalives, and tool-
             dispatch over SSE that stdio masks.
 
+  Layer 3 — broad tool surface: exercises one representative call
+            from each tool category (taxonomy, chunks/semantic search,
+            bibliography, lexicon, figures, profiles).  Checks that
+            tools return plausible non-error results without validating
+            corpus-specific content — suitable for both the 4-paper
+            demo and a full production corpuscle.
+
 Starts the server as a subprocess, waits for it to bind, runs the
 checks, shuts it down cleanly.  No external deps — stdlib for layer
-1, the ``mcp`` Python SDK (already a dep) for layer 2.
+1, the ``mcp`` Python SDK (already a dep) for layers 2 and 3.
 
 Usage:
     python tools/smoke_test_sse.py output
     python tools/smoke_test_sse.py output --port 18080 --skip-layer2
+    python tools/smoke_test_sse.py output --skip-layer3
 """
 
 from __future__ import annotations
@@ -139,7 +147,7 @@ def layer1_http(host: str, port: int, token: str) -> int:
     return rc
 
 
-# ── Layer 2: MCP client over SSE ────────────────────────────────────
+# ── Layer 2: MCP handshake + core tools ────────────────────────────
 
 async def layer2_mcp_client(host: str, port: int, token: str) -> int:
     _section("Layer 2: MCP client over SSE")
@@ -215,6 +223,297 @@ async def layer2_mcp_client(host: str, port: int, token: str) -> int:
     return rc
 
 
+# ── Layer 3: broad tool surface ─────────────────────────────────────
+
+async def layer3_tool_coverage(host: str, port: int, token: str) -> int:
+    """Exercise one representative call from each tool category.
+
+    Checks for non-error responses and expected top-level fields;
+    does not validate corpus-specific content so the tests work on
+    both the 4-paper demo and a full production corpuscle.
+    """
+    _section("Layer 3: broad tool surface")
+    try:
+        from mcp import ClientSession
+        from mcp.client.sse import sse_client
+    except ImportError as e:
+        _info(f"mcp SDK not importable: {e} — skipping layer 3")
+        return 0
+
+    url = f"http://{host}:{port}/sse"
+    headers = {"Authorization": f"Bearer {token}"}
+    rc = 0
+
+    async with sse_client(url, headers=headers) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # ── Discover a real paper hash for paper-keyed tests ────
+            first_hash = None
+            try:
+                r = await session.call_tool("list_papers", {"limit": 1})
+                papers = _parse_tool_result(r)
+                if isinstance(papers, list) and papers:
+                    first_hash = papers[0].get("hash")
+            except Exception:
+                pass
+
+            # ── Corpus summary ──────────────────────────────────────
+            _section("Layer 3a: corpus-level tools")
+            try:
+                r = await session.call_tool("corpus_summary", {})
+                d = _parse_tool_result(r)
+                if isinstance(d, dict) and "paper_count" in d and d["paper_count"] > 0:
+                    _ok(f"corpus_summary → {d['paper_count']} papers, "
+                        f"{d.get('chunk_count', '?')} chunks")
+                else:
+                    rc |= _fail(f"corpus_summary unexpected: {d!r}")
+            except Exception as e:
+                rc |= _fail(f"corpus_summary raised: {e}")
+
+            # ── Taxonomy tools ──────────────────────────────────────
+            _section("Layer 3b: taxonomy tools")
+
+            # search_taxon — use a broadly-valid name present in any
+            # marine corpus; the important check is that the tool runs
+            # without error and returns a dict with a "found" key.
+            taxon_hit = None
+            try:
+                r = await session.call_tool(
+                    "search_taxon", {"name": "Siphonophorae"}
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, dict) and "found" in d:
+                    if d["found"]:
+                        taxon_hit = d.get("taxon_id") or "Siphonophorae"
+                        _ok(f"search_taxon(Siphonophorae) → found, "
+                            f"taxon_id={d.get('taxon_id')!r}")
+                    else:
+                        # Demo corpus may not have siphonophore taxonomy
+                        _ok("search_taxon(Siphonophorae) → not found "
+                            "(expected on demo corpus)")
+                else:
+                    rc |= _fail(f"search_taxon unexpected: {d!r}")
+            except Exception as e:
+                rc |= _fail(f"search_taxon raised: {e}")
+
+            # list_valid_species_under
+            try:
+                r = await session.call_tool(
+                    "list_valid_species_under",
+                    {"parent_taxon_name": "Siphonophorae"},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"list_valid_species_under(Siphonophorae) → "
+                        f"{len(d)} species")
+                elif isinstance(d, dict) and "error" in d:
+                    _ok(f"list_valid_species_under → error (expected on "
+                        f"demo: {d['error']!r})")
+                else:
+                    rc |= _fail(f"list_valid_species_under unexpected: {d!r}")
+            except Exception as e:
+                rc |= _fail(f"list_valid_species_under raised: {e}")
+
+            # get_papers_for_taxon
+            try:
+                r = await session.call_tool(
+                    "get_papers_for_taxon",
+                    {"taxon_name": "Physalia", "limit": 3},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"get_papers_for_taxon(Physalia) → {len(d)} papers")
+                elif isinstance(d, dict):
+                    # wrapped response or error dict — acceptable
+                    _ok(f"get_papers_for_taxon → dict ({list(d)[:3]})")
+                else:
+                    rc |= _fail(f"get_papers_for_taxon unexpected: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"get_papers_for_taxon raised: {e}")
+
+            # get_taxon_dossier — the main workhorse dossier tool
+            try:
+                r = await session.call_tool(
+                    "get_taxon_dossier",
+                    {"taxon_name": "Physalia", "max_papers": 3},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, dict):
+                    keys = set(d.keys())
+                    expected = {"taxon", "papers"}
+                    if keys & expected:
+                        _ok(f"get_taxon_dossier(Physalia) → keys: "
+                            f"{sorted(keys)[:6]}")
+                    elif "error" in keys:
+                        _ok(f"get_taxon_dossier → error dict (demo OK: "
+                            f"{d['error']!r})")
+                    else:
+                        rc |= _fail(f"get_taxon_dossier unexpected keys: {keys}")
+                else:
+                    rc |= _fail(f"get_taxon_dossier unexpected type: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"get_taxon_dossier raised: {e}")
+
+            # ── Chunks / semantic search ────────────────────────────
+            _section("Layer 3c: chunk tools")
+
+            # get_chunks_for_topic — semantic search, requires LanceDB
+            try:
+                r = await session.call_tool(
+                    "get_chunks_for_topic",
+                    {"topic": "nectophore morphology", "limit": 3},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"get_chunks_for_topic → {len(d)} chunks")
+                    if d:
+                        has_text = "text" in d[0] or "chunk_id" in d[0]
+                        if not has_text:
+                            rc |= _fail(
+                                f"chunk missing text/chunk_id: {list(d[0])}"
+                            )
+                elif isinstance(d, dict) and "error" in d:
+                    _ok(f"get_chunks_for_topic → error (no embeddings? "
+                        f"{d['error']!r})")
+                else:
+                    rc |= _fail(f"get_chunks_for_topic unexpected: {d!r}")
+            except Exception as e:
+                rc |= _fail(f"get_chunks_for_topic raised: {e}")
+
+            # get_chunks (paper-keyed, requires a real hash)
+            if first_hash:
+                try:
+                    r = await session.call_tool(
+                        "get_chunks",
+                        {"paper_hash": first_hash, "with_text": False},
+                    )
+                    d = _parse_tool_result(r)
+                    if isinstance(d, list):
+                        _ok(f"get_chunks({first_hash[:8]}…) → "
+                            f"{len(d)} chunks")
+                    else:
+                        rc |= _fail(f"get_chunks unexpected: {type(d)}")
+                except Exception as e:
+                    rc |= _fail(f"get_chunks raised: {e}")
+            else:
+                _info("skipping get_chunks (no paper hash available)")
+
+            # ── Bibliography tools ──────────────────────────────────
+            _section("Layer 3d: bibliography tools")
+
+            # get_bibliography (paper-keyed)
+            if first_hash:
+                try:
+                    r = await session.call_tool(
+                        "get_bibliography",
+                        {"paper_hash": first_hash, "limit": 5},
+                    )
+                    d = _parse_tool_result(r)
+                    if isinstance(d, list):
+                        _ok(f"get_bibliography({first_hash[:8]}…) → "
+                            f"{len(d)} refs")
+                    else:
+                        rc |= _fail(f"get_bibliography unexpected: {type(d)}")
+                except Exception as e:
+                    rc |= _fail(f"get_bibliography raised: {e}")
+            else:
+                _info("skipping get_bibliography (no paper hash available)")
+
+            # get_missing_references — exercises biblio_authority.sqlite
+            try:
+                r = await session.call_tool(
+                    "get_missing_references", {"limit": 5}
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"get_missing_references → {len(d)} missing refs")
+                else:
+                    rc |= _fail(f"get_missing_references unexpected: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"get_missing_references raised: {e}")
+
+            # get_works_by_author — a well-known siphonophore author
+            try:
+                r = await session.call_tool(
+                    "get_works_by_author", {"surname": "Huxley"}
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"get_works_by_author(Huxley) → {len(d)} works")
+                elif isinstance(d, dict):
+                    _ok(f"get_works_by_author → dict ({list(d)[:3]})")
+                else:
+                    rc |= _fail(f"get_works_by_author unexpected: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"get_works_by_author raised: {e}")
+
+            # ── Lexicon tools ───────────────────────────────────────
+            _section("Layer 3e: lexicon tools")
+
+            try:
+                r = await session.call_tool(
+                    "lexicon_matrix",
+                    {"category": "anatomy", "max_terms": 5, "max_papers": 5},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, dict):
+                    if "error" in d:
+                        _ok(f"lexicon_matrix → error (no lexicon? "
+                            f"{d['error']!r})")
+                    elif "terms" in d or "matrix" in d or "papers" in d:
+                        _ok(f"lexicon_matrix(anatomy) → keys: "
+                            f"{sorted(d)[:5]}")
+                    else:
+                        rc |= _fail(
+                            f"lexicon_matrix unexpected keys: {sorted(d)}"
+                        )
+                else:
+                    rc |= _fail(f"lexicon_matrix unexpected: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"lexicon_matrix raised: {e}")
+
+            # ── Figures tools ───────────────────────────────────────
+            _section("Layer 3f: figure tools")
+
+            try:
+                r = await session.call_tool(
+                    "get_figures_for_taxon",
+                    {"taxon_name": "Physalia", "limit": 3},
+                )
+                d = _parse_tool_result(r)
+                if isinstance(d, list):
+                    _ok(f"get_figures_for_taxon(Physalia) → {len(d)} figures")
+                elif isinstance(d, dict) and "error" in d:
+                    _ok(f"get_figures_for_taxon → error (demo OK: "
+                        f"{d['error']!r})")
+                else:
+                    rc |= _fail(
+                        f"get_figures_for_taxon unexpected: {type(d)}"
+                    )
+            except Exception as e:
+                rc |= _fail(f"get_figures_for_taxon raised: {e}")
+
+            # ── Profiles tools ──────────────────────────────────────
+            _section("Layer 3g: profile tools")
+
+            try:
+                r = await session.call_tool("list_output_profiles", {})
+                d = _parse_tool_result(r)
+                if isinstance(d, dict) and "profiles" in d:
+                    _ok(f"list_output_profiles → "
+                        f"{len(d['profiles'])} profiles: "
+                        f"{list(d['profiles'])}")
+                elif isinstance(d, dict):
+                    _ok(f"list_output_profiles → {sorted(d)[:5]}")
+                else:
+                    rc |= _fail(f"list_output_profiles unexpected: {type(d)}")
+            except Exception as e:
+                rc |= _fail(f"list_output_profiles raised: {e}")
+
+    return rc
+
+
 def _parse_tool_result(result):
     """Best-effort extraction of a JSON payload from an MCP tool
     result's content blocks.  Returns the parsed value or None."""
@@ -249,6 +548,8 @@ def main() -> int:
     parser.add_argument("--skip-layer2", action="store_true",
                         help="Skip the MCP-client layer (useful when the "
                              "mcp SDK isn't installed in the current env)")
+    parser.add_argument("--skip-layer3", action="store_true",
+                        help="Skip the broad tool-coverage layer")
     parser.add_argument("--server-startup-timeout", type=float, default=15.0,
                         help="Seconds to wait for the server to bind (default: 15)")
     args = parser.parse_args()
@@ -301,6 +602,10 @@ def main() -> int:
             if not args.skip_layer2:
                 rc |= asyncio.run(
                     layer2_mcp_client(args.host, args.port, token)
+                )
+            if not args.skip_layer3:
+                rc |= asyncio.run(
+                    layer3_tool_coverage(args.host, args.port, token)
                 )
 
         finally:


### PR DESCRIPTION
First of 3 PRs making `corpus run` HPC-capable, so the full-corpus production run uses the **same CLI users run** instead of the divergent raw-`pipeline.main` path in the SLURM scripts (you flagged this dogfooding gap).

## This PR — the engine (CLI + orchestrator)
- **`corpus run --only {extract,vision,embed,post,bundle}`** runs a single phase, so each maps to its own SLURM job/partition: extract (CPU), vision (GPU Pass 3b refresh), embed (GPU), post (cross-paper DBs), bundle (served-bundle distill). **Omit `--only` → the full chain on one node (unchanged default).**
- **`--batch-index N --batch-size M`** slice the extract + vision phases into job-array tasks (plumbed cli → orchestrator → `pipeline.main`'s existing slicing).
- `_cmd_run` gates preconditions/prune/flag-invalidation to the extract phase, distills the bundle only on a full run (or `--only bundle`), and writes `run.log` on a full run or the post phase.
- orchestrator: new `vision` phase (`--refresh-vision --no-grobid --no-taxa --figure-panels vision-local`, forcing a vision backend since extract may use the ocr floor); `--only`/`--batch` args; `select_steps()` factored out for testing; `ONLY_PHASES` map.

Additive CLI (not the frozen MCP surface). **PR [2/3]** rewrites the SLURM scripts to drive everything through `corpus run --only …` + a committed Bouchet `config.yaml`; **PR [3/3]** rewrites BOUCHET.md fully explicit.

## Tests
`tests/test_corpus_run_hpc.py` (13): flag parse, `_build_orchestrator_argv` passthrough (incl. bundle never forwarded), `select_steps` phase resolution, extract/vision step argv (batch flags; vision forces a backend; honors configured vision-claude). pyflakes clean; full suite **620 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)